### PR TITLE
Security Audit & Hardening: Fix vulnerabilities, memory leaks, and stabilize PHP API

### DIFF
--- a/LogApi/LogApi.cpp
+++ b/LogApi/LogApi.cpp
@@ -4,648 +4,547 @@
 CLogApi gLogApi;
 
 // On server activate event
-void CLogApi::ServerActivate()
-{
-	// Plugin is running
-	this->m_Running = true;
+void CLogApi::ServerActivate() {
+  // Plugin is running
+  this->m_Running = true;
 
-	// If has Delay cvar
-	if (gLogCvar.m_Delay)
-	{
-		// If has Delay cvar value
-		if (gLogCvar.m_Delay->value > 0.0f)
-		{
-			// Reset next frame time
-			this->m_FrameTime = (gpGlobals->time + gLogCvar.m_Delay->value);
-		}
-	}
-	else
-	{
-		this->m_FrameTime = (gpGlobals->time + 60.0);
-	}
+  // If has Delay cvar
+  if (gLogCvar.m_Delay) {
+    // If has Delay cvar value
+    if (gLogCvar.m_Delay->value > 0.0f) {
+      // Reset next frame time
+      this->m_FrameTime = (gpGlobals->time + gLogCvar.m_Delay->value);
+    }
+  } else {
+    this->m_FrameTime = (gpGlobals->time + 60.0);
+  }
 
-	try
-	{
-		// File stream
-		FILE* fp = fopen(LOG_API_FILE_EVENTS, "r");
+  try {
+    // File stream
+    FILE *fp = fopen(LOG_API_FILE_EVENTS, "r");
 
-		if (fp)
-		{
-			// Set file pointer to end of file
-			fseek(fp, 0, SEEK_END);
+    if (fp) {
+      // Set file pointer to end of file
+      fseek(fp, 0, SEEK_END);
 
-			// Get final position
-			long fs = ftell(fp);
+      // Get final position
+      long fs = ftell(fp);
 
-			// Set file pointer to start of file
-			fseek(fp, 0, SEEK_SET);
+      // Set file pointer to start of file
+      fseek(fp, 0, SEEK_SET);
 
-			// Create empty std::string with file size
-			std::string buffer(fs, '\0');
+      // Create empty std::string with file size
+      std::string buffer(fs, '\0');
 
-			// Read file to std::string buffer
-			size_t elements = fread(&buffer[0], 1, fs, fp);
+      // Read file to std::string buffer
+      size_t elements = fread(&buffer[0], 1, fs, fp);
 
-			// If read something
-			if (elements > 0)
-			{
-				// Read data
-				auto json = nlohmann::ordered_json::parse(buffer, nullptr, true, true);
+      // If read something
+      if (elements > 0) {
+        // Read data
+        auto json = nlohmann::ordered_json::parse(buffer, nullptr, true, true);
 
-				// Loop each item
-				for (auto const& event : json.items())
-				{
-					// Insert event as enabled / disabled
-					this->m_Events.insert(std::make_pair(event.key(), event.value().get<bool>()));
-				}
-			}
+        // Loop each item
+        for (auto const &event : json.items()) {
+          // Insert event as enabled / disabled
+          this->m_Events.insert(
+              std::make_pair(event.key(), event.value().get<bool>()));
+        }
+      }
 
-			// Close file pointer
-			fclose(fp);
-		}
-		else
-		{
-			// Failed on error
-			LOG_CONSOLE(PLID, "[%s] Failed to open file: %s", __func__, LOG_API_FILE_EVENTS);
-		}
-	}
-	catch (const nlohmann::ordered_json::parse_error& e)
-	{
-		// JSON exeption errors
-		LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
-	}
+      // Close file pointer
+      fclose(fp);
+    } else {
+      // Failed on error
+      LOG_CONSOLE(PLID, "[%s] Failed to open file: %s", __func__,
+                  LOG_API_FILE_EVENTS);
+    }
+  } catch (const nlohmann::ordered_json::parse_error &e) {
+    // JSON exeption errors
+    LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
+  }
 }
 
 // On server deactivate
-void CLogApi::ServerDeactivate()
-{
-	// Plugin is not running
-	this->m_Running = false;
+void CLogApi::ServerDeactivate() {
+  // Plugin is not running
+  this->m_Running = false;
 }
 
 // On server frame
-void CLogApi::ServerFrame()
-{
-	// If variable is not null
-	if (gLogCvar.m_Delay)
-	{
-		// If is set more than 5 seconds
-		if (gLogCvar.m_Delay->value > 5.0f)
-		{
-			// If frame time was passed
-			if (gpGlobals->time >= this->m_FrameTime)
-			{
-				// Is Running
-				if (this->m_Running)
-				{
-					// Send server info
-					gLogEvent.ServerInfo();
-	
-					// Set next frame time
-					this->m_FrameTime = (gpGlobals->time + gLogCvar.m_Delay->value);
-				}
-			}
-		}
-	}
+void CLogApi::ServerFrame() {
+  // If variable is not null
+  if (gLogCvar.m_Delay) {
+    // If is set more than 5 seconds
+    if (gLogCvar.m_Delay->value > 5.0f) {
+      // If frame time was passed
+      if (gpGlobals->time >= this->m_FrameTime) {
+        // Is Running
+        if (this->m_Running) {
+          // Send server info
+          gLogEvent.ServerInfo();
+
+          // Set next frame time
+          this->m_FrameTime = (gpGlobals->time + gLogCvar.m_Delay->value);
+        }
+      }
+    }
+  }
 }
 
 // Check if event is enabled
-int CLogApi::EventEnabled(const char* EventName)
-{
-	// If is not null
-	if (EventName)
-	{
-		// If string is not empty
-		if (EventName[0u] != '\0')
-		{
-			// If log api is enabled
-			if (gLogCvar.m_Enable)
-			{
-				if (gLogCvar.m_Enable->value)
-				{
-					// If log api has address
-					if (gLogCvar.m_Address)
-					{
-						// If log api has target address
-						if (gLogCvar.m_Address->string)
-						{
-							// If events is not empty
-							if (!this->m_Events.empty())
-							{
-								// Find event by name
-								if (this->m_Events.find(EventName) != this->m_Events.end())
-								{
-									// Retorn enable / disabled
-									return this->m_Events[EventName];
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+int CLogApi::EventEnabled(const char *EventName) {
+  // If is not null
+  if (EventName) {
+    // If string is not empty
+    if (EventName[0u] != '\0') {
+      // If log api is enabled
+      if (gLogCvar.m_Enable) {
+        if (gLogCvar.m_Enable->value) {
+          // If log api has address
+          if (gLogCvar.m_Address) {
+            // If log api has target address
+            if (gLogCvar.m_Address->string) {
+              // If events is not empty
+              if (!this->m_Events.empty()) {
+                // Find event by name
+                if (this->m_Events.find(EventName) != this->m_Events.end()) {
+                  // Retorn enable / disabled
+                  return this->m_Events[EventName];
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
-	// Return 0
-	return 0;
+  // Return 0
+  return 0;
 }
 
 // Send event
-void CLogApi::SendEvent(int EventIndex, nlohmann::ordered_json Event)
-{
-	// Is Running
-	if (this->m_Running)
-	{
-		// If address is set
-		if (gLogCvar.m_Address)
-		{
-			// If is enabled
-			if (gLogCvar.m_Enable)
-			{
-				// If log api is enabled
-				if (gLogCvar.m_Enable->value)
-				{
-					// If log api has target address
-					if (gLogCvar.m_Address->string)
-					{
-						// If JSON is not empty
-						if (!Event.empty())
-						{
-							if (gLogCvar.m_Timeout)
-							{
-								if (gLogCvar.m_Bearer)
-								{
-									// POST to webserver
-									gLogCurl.PostJSON(gLogCvar.m_Address->string, (long)gLogCvar.m_Timeout->value, gLogCvar.m_Bearer->string, Event.dump(), EventIndex);
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+void CLogApi::SendEvent(int EventIndex, nlohmann::ordered_json Event) {
+  // Is Running
+  if (this->m_Running) {
+    // If address is set
+    if (gLogCvar.m_Address) {
+      // If is enabled
+      if (gLogCvar.m_Enable) {
+        // If log api is enabled
+        if (gLogCvar.m_Enable->value) {
+          // If log api has target address
+          if (gLogCvar.m_Address->string) {
+            // If JSON is not empty
+            if (!Event.empty()) {
+              if (gLogCvar.m_Timeout) {
+                if (gLogCvar.m_Bearer) {
+                  // POST to webserver
+                  gLogCurl.PostJSON(gLogCvar.m_Address->string,
+                                    (long)gLogCvar.m_Timeout->value,
+                                    gLogCvar.m_Bearer->string, Event.dump(),
+                                    EventIndex);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 // Callback
-void CLogApi::CallbackResult(CURL* ch, size_t Size, const char* Memory, int EventIndex)
-{
-	if (ch)
-	{
-		// HTTP Status Code
-		long HttpResponseCode = 0;
+void CLogApi::CallbackResult(CURL *ch, size_t Size, const char *Memory,
+                             int EventIndex) {
+  if (ch) {
+    // HTTP Status Code
+    long HttpResponseCode = 0;
 
-		// If can get info
-		if (curl_easy_getinfo(ch, CURLINFO_RESPONSE_CODE, &HttpResponseCode) == CURLE_OK)
-		{
-			// If response code is ok
-			if (HttpResponseCode == 200)
-			{
-				// If memory is not null
-				if (Memory)
-				{
-					// If is not empty
-					if (Memory[0u] != '\0')
-					{
-						try
-						{
-							// Parse json data to result
-							auto Result = nlohmann::ordered_json::parse(Memory, nullptr, true, true);
+    // If can get info
+    if (curl_easy_getinfo(ch, CURLINFO_RESPONSE_CODE, &HttpResponseCode) ==
+        CURLE_OK) {
+      // If response code is ok
+      if (HttpResponseCode == 200) {
+        // If memory is not null
+        if (Memory) {
+          // If is not empty
+          if (Memory[0u] != '\0') {
+            try {
+              // Parse json data to result
+              auto Result =
+                  nlohmann::ordered_json::parse(Memory, nullptr, true, true);
 
-							// If is not empty
-							if (!Result.empty())
-							{
-								// If has data size
-								if (Result.size() > 0)
-								{
-									// Call event result
-									gLogApi.EventResult(EventIndex, Result);
-								}
-							} 
-						}
-						catch (const nlohmann::ordered_json::parse_error& e)
-						{
-							// Log
-							LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
-						}
-					}
-				}
-			}
-			else
-			{
-				// Log
-				LOG_CONSOLE(PLID, "[%s] Unknow response from server: HTTP Code %d, check log_api_address.", __func__, HttpResponseCode);
-			}
-		}
-
-		// Clear
-		curl_easy_cleanup(ch);
-	}
+              // If is not empty
+              if (!Result.empty()) {
+                // If has data size
+                if (Result.size() > 0) {
+                  // Call event result
+                  gLogApi.EventResult(EventIndex, Result);
+                }
+              }
+            } catch (const nlohmann::ordered_json::parse_error &e) {
+              // Log
+              LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
+            }
+          }
+        }
+      } else {
+        // Log
+        LOG_CONSOLE(PLID,
+                    "[%s] Unknow response from server: HTTP Code %d, check "
+                    "log_api_address.",
+                    __func__, HttpResponseCode);
+      }
+    }
+  }
 }
 
 // Parse event result
-void CLogApi::EventResult(int EventIndex, nlohmann::ordered_json Data)
-{
-	// Check if has event 'ServerCommand' result from api
-	if (Data.contains("ServerCommand"))
-	{
-		this->ServerCommand(EventIndex, Data);
-	}
+void CLogApi::EventResult(int EventIndex, nlohmann::ordered_json Data) {
+  // Check if has event 'ServerCommand' result from api
+  if (Data.contains("ServerCommand")) {
+    this->ServerCommand(EventIndex, Data);
+  }
 
-	// Check if has event 'ShowMenu' result from api
-	if (Data.contains("ShowMenu"))
-	{
-		this->ShowMenu(EventIndex, Data);
-	}
+  // Check if has event 'ShowMenu' result from api
+  if (Data.contains("ShowMenu")) {
+    this->ShowMenu(EventIndex, Data);
+  }
 
-	// Check if has event 'ClientPrint' result from api
-	if (Data.contains("ClientPrint"))
-	{
-		this->ClientPrint(EventIndex, Data);
-	}
+  // Check if has event 'ClientPrint' result from api
+  if (Data.contains("ClientPrint")) {
+    this->ClientPrint(EventIndex, Data);
+  }
 
-	// Check if has event 'PrintChat' result from api
-	if (Data.contains("PrintChat"))
-	{
-		this->PrintChat(EventIndex, Data);
-	}
+  // Check if has event 'PrintChat' result from api
+  if (Data.contains("PrintChat")) {
+    this->PrintChat(EventIndex, Data);
+  }
 
-	// Check if has event 'ShowHudMessage' result from api
-	if (Data.contains("ShowHudMessage"))
-	{
-		this->ShowHudMessage(EventIndex, Data);
-	}
+  // Check if has event 'ShowHudMessage' result from api
+  if (Data.contains("ShowHudMessage")) {
+    this->ShowHudMessage(EventIndex, Data);
+  }
 }
 
 // Execute server command from result
-void CLogApi::ServerCommand(int EventIndex, nlohmann::ordered_json Data)
-{
-	// If is not empty
-	if (!Data[__func__].empty())
-	{
-		try
-		{
-			// Check if event result is string
-			if (Data[__func__].is_string())
-			{
-				// Get Command
-				auto String = Data[__func__].get<std::string>();
+void CLogApi::ServerCommand(int EventIndex, nlohmann::ordered_json Data) {
+  if (gLogCvar.m_ExecCommands) {
+    if (gLogCvar.m_ExecCommands->value <= 0.0f) {
+      return;
+    }
+  }
 
-				// If command is not empty
-				if (!String.empty())
-				{
-					// Execute command
-					gLogUtil.ServerExecute(String);
-				}
-			}
-			//
-			// Check if event result is array
-			else if (Data[__func__].is_array())
-			{
-				// Loop commands
-				for (auto it = Data[__func__].begin(); it != Data[__func__].end(); ++it)
-				{
-					// If is strimg
-					if (it.value().is_string())
-					{
-						// If is not empty
-						if (!it.value().empty())
-						{
-							// Get string of this command
-							auto String = std::string(it.value());
+  // If is not empty
+  if (!Data[__func__].empty()) {
+    try {
+      // Check if event result is string
+      if (Data[__func__].is_string()) {
+        // Get Command
+        auto String = Data[__func__].get<std::string>();
 
-							// If is not empty
-							if (!String.empty())
-							{
-								// Execute command
-								gLogUtil.ServerExecute(String);
-							}
-						}
-					}
-				}
-			}
-		}
-		catch (const nlohmann::ordered_json::exception& e)
-		{
-			LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
-		}
-	}
+        // If command is not empty
+        if (!String.empty()) {
+          // Execute command
+          gLogUtil.ServerExecute(String);
+        }
+      }
+      //
+      // Check if event result is array
+      else if (Data[__func__].is_array()) {
+        // Loop commands
+        for (auto it = Data[__func__].begin(); it != Data[__func__].end();
+             ++it) {
+          // If is strimg
+          if (it.value().is_string()) {
+            // If is not empty
+            if (!it.value().empty()) {
+              // Get string of this command
+              auto String = std::string(it.value());
+
+              // If is not empty
+              if (!String.empty()) {
+                // Execute command
+                gLogUtil.ServerExecute(String);
+              }
+            }
+          }
+        }
+      }
+    } catch (const nlohmann::ordered_json::exception &e) {
+      LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
+    }
+  }
 }
 
 // Open menu from result
-void CLogApi::ShowMenu(int EventIndex, nlohmann::ordered_json Data)
-{
-	if (!Data[__func__].empty())
-	{
-		if (Data[__func__].is_object())
-		{
-			if (!Data[__func__]["Items"].empty())
-			{
-				if (Data[__func__]["Items"].is_array())
-				{
-					try
-					{
-						auto Title = Data[__func__]["Title"].get<std::string>();
+void CLogApi::ShowMenu(int EventIndex, nlohmann::ordered_json Data) {
+  if (!Data[__func__].empty()) {
+    if (Data[__func__].is_object()) {
+      if (!Data[__func__]["Items"].empty()) {
+        if (Data[__func__]["Items"].is_array()) {
+          try {
+            auto Title = Data[__func__]["Title"].get<std::string>();
 
-						auto Exit = Data[__func__]["Exit"].get<bool>();
+            auto Exit = Data[__func__]["Exit"].get<bool>();
 
-						auto Callback = Data[__func__]["Callback"].get<std::string>();
+            auto Callback = Data[__func__]["Callback"].get<std::string>();
 
-						if (Data[__func__]["EntityId"].is_number_integer())
-						{
-							auto EntityId = Data[__func__]["EntityId"].get<int>();
+            if (Data[__func__]["EntityId"].is_number_integer()) {
+              auto EntityId = Data[__func__]["EntityId"].get<int>();
 
-							if (EntityId)
-							{
-								this->Menu(EntityId, Title, Exit, Callback, Data[__func__]["Items"]);
-							}
-							else
-							{
-								auto Players = gLogUtil.GetPlayers();
+              if (EntityId) {
+                this->Menu(EntityId, Title, Exit, Callback,
+                           Data[__func__]["Items"]);
+              } else {
+                auto Players = gLogUtil.GetPlayers();
 
-								if (!Players.empty())
-								{
-									for (auto Player : Players)
-									{
-										this->Menu(Player->entindex(), Title, Exit, Callback, Data[__func__]["Items"]);
-									}
-								}
-							}
-						}
-						else if (Data[__func__]["EntityId"].is_array())
-						{
-							for (auto it = Data[__func__]["EntityId"].begin(); it != Data[__func__]["EntityId"].end(); ++it)
-							{
-								if (it.value().is_number_integer())
-								{
-									this->Menu(it.value().get<int>(), Title, Exit, Callback, Data[__func__]["Items"]);
-								}
-							}
-						}
-					}
-					catch (const nlohmann::ordered_json::exception& e)
-					{
-						LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
-					}
-				}
-				else
-				{
-					LOG_CONSOLE(PLID, "[%s] Menu is empty", __func__);
-				}
-			}
-		}
-	}
+                if (!Players.empty()) {
+                  for (auto Player : Players) {
+                    this->Menu(Player->entindex(), Title, Exit, Callback,
+                               Data[__func__]["Items"]);
+                  }
+                }
+              }
+            } else if (Data[__func__]["EntityId"].is_array()) {
+              for (auto it = Data[__func__]["EntityId"].begin();
+                   it != Data[__func__]["EntityId"].end(); ++it) {
+                if (it.value().is_number_integer()) {
+                  this->Menu(it.value().get<int>(), Title, Exit, Callback,
+                             Data[__func__]["Items"]);
+                }
+              }
+            }
+          } catch (const nlohmann::ordered_json::exception &e) {
+            LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
+          }
+        } else {
+          LOG_CONSOLE(PLID, "[%s] Menu is empty", __func__);
+        }
+      }
+    }
+  }
 }
 
 // Open menu function
-void CLogApi::Menu(int EntityIndex, std::string Title, bool Exit, std::string Callback, nlohmann::ordered_json Items)
-{
-	auto Player = UTIL_PlayerByIndexSafe(EntityIndex);
+void CLogApi::Menu(int EntityIndex, std::string Title, bool Exit,
+                   std::string Callback, nlohmann::ordered_json Items) {
+  auto Player = UTIL_PlayerByIndexSafe(EntityIndex);
 
-	if (Player)
-	{
-		if (!Player->IsBot())
-		{
-			if (Player->IsPlayer())
-			{
-				gLogMenu[EntityIndex].Create(Title, Callback, Exit);
+  if (Player) {
+    if (!Player->IsBot()) {
+      if (Player->IsPlayer()) {
+        gLogMenu[EntityIndex].Create(Title, Callback, Exit);
 
-				for (auto it = Items.begin(); it != Items.end(); ++it)
-				{
-					auto Option = it.value();
+        for (auto it = Items.begin(); it != Items.end(); ++it) {
+          auto Option = it.value();
 
-					if (Option.is_object())
-					{
-						if (!Option.empty())
-						{
-							auto Info = Option["Info"].get<std::string>();
+          if (Option.is_object()) {
+            if (!Option.empty()) {
+              auto Info = Option["Info"].get<std::string>();
 
-							auto Text = Option["Text"].get<std::string>();
+              auto Text = Option["Text"].get<std::string>();
 
-							auto Disabled = Option["Disabled"].get<bool>();
+              auto Disabled = Option["Disabled"].get<bool>();
 
-							auto Extra = Option["Extra"].get<std::string>();
+              auto Extra = Option["Extra"].get<std::string>();
 
-							gLogMenu[EntityIndex].AddItem(Info, Text, Disabled, Extra);
-						}
-					}
-				}
+              gLogMenu[EntityIndex].AddItem(Info, Text, Disabled, Extra);
+            }
+          }
+        }
 
-				gLogMenu[EntityIndex].Show(EntityIndex);
-			}
-		}
-	}
+        gLogMenu[EntityIndex].Show(EntityIndex);
+      }
+    }
+  }
 }
 
 // Open menu function handler
-void CLogApi::MenuHandle(int EntityIndex, std::string Callback, P_MENU_ITEM Item)
-{
-	gLogEvent.ClientMenuHandle(INDEXENT(EntityIndex), Callback, Item);
+void CLogApi::MenuHandle(int EntityIndex, std::string Callback,
+                         P_MENU_ITEM Item) {
+  gLogEvent.ClientMenuHandle(INDEXENT(EntityIndex), Callback, Item);
 }
 
 // Print to client from result
-void CLogApi::ClientPrint(int EventIndex, nlohmann::ordered_json Data)
-{
-	// If is not empty
-	if (!Data[__func__].empty())
-	{
-		try
-		{
-			if (Data[__func__].is_object())
-			{
-				// If is not empty
-				if (!Data[__func__]["EntityId"].empty() && !Data[__func__]["PrintType"].empty() && !Data[__func__]["Message"].empty())
-				{
-					// Entity index
-					auto EntityId = Data[__func__]["EntityId"].get<int>();
+void CLogApi::ClientPrint(int EventIndex, nlohmann::ordered_json Data) {
+  // If is not empty
+  if (!Data[__func__].empty()) {
+    try {
+      if (Data[__func__].is_object()) {
+        // If is not empty
+        if (!Data[__func__]["EntityId"].empty() &&
+            !Data[__func__]["PrintType"].empty() &&
+            !Data[__func__]["Message"].empty()) {
+          // Entity index
+          auto EntityId = Data[__func__]["EntityId"].get<int>();
 
-					// Print Type
-					auto PrintType = Data[__func__]["PrintType"].get<int>();
+          // Print Type
+          auto PrintType = Data[__func__]["PrintType"].get<int>();
 
-					// Get message string
-					auto Message = Data[__func__]["Message"].get<std::string>();
+          // Get message string
+          auto Message = Data[__func__]["Message"].get<std::string>();
 
-					// Entity pointer
-					edict_t* pEntity = nullptr;
+          // Entity pointer
+          edict_t *pEntity = nullptr;
 
-					// If has entity index
-					if (EntityId > 0)
-					{
-						// Get entity pointer
-						pEntity = FNullEnt(INDEXENT(EntityId)) ? INDEXENT(EntityId) : nullptr;
-					}
+          // If has entity index
+          if (EntityId > 0) {
+            // Get entity pointer
+            pEntity =
+                FNullEnt(INDEXENT(EntityId)) ? INDEXENT(EntityId) : nullptr;
+          }
 
-					// If is not empty
-					if (!Message.empty())
-					{
-						// Print to entity
-						gLogUtil.ClientPrint(pEntity, PrintType, "%s", Message.c_str());
-					}
-				}
-			}
-		}
-		catch (const nlohmann::ordered_json::exception& e)
-		{
-			LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
-		}
-	}
+          // If is not empty
+          if (!Message.empty()) {
+            // Print to entity
+            gLogUtil.ClientPrint(pEntity, PrintType, "%s", Message.c_str());
+          }
+        }
+      }
+    } catch (const nlohmann::ordered_json::exception &e) {
+      LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
+    }
+  }
 }
 
 // Print to player chat from result
-void CLogApi::PrintChat(int EventIndex, nlohmann::ordered_json Data)
-{
-	// If is not empty
-	if (!Data[__func__].empty())
-	{
-		try
-		{
-			if (Data[__func__].is_object())
-			{
-				// If is not empty
-				if (!Data[__func__]["EntityId"].empty() && !Data[__func__]["Message"].empty())
-				{
-					// Entity pointer
-					edict_t* pEntity = nullptr;
+void CLogApi::PrintChat(int EventIndex, nlohmann::ordered_json Data) {
+  // If is not empty
+  if (!Data[__func__].empty()) {
+    try {
+      if (Data[__func__].is_object()) {
+        // If is not empty
+        if (!Data[__func__]["EntityId"].empty() &&
+            !Data[__func__]["Message"].empty()) {
+          // Entity pointer
+          edict_t *pEntity = nullptr;
 
-					// Entity index
-					auto EntityId = Data[__func__]["EntityId"].get<int>();
+          // Entity index
+          auto EntityId = Data[__func__]["EntityId"].get<int>();
 
-					// Get message string
-					auto Message = Data[__func__]["Message"].get<std::string>();
+          // Get message string
+          auto Message = Data[__func__]["Message"].get<std::string>();
 
-					// If has entity index
-					if (EntityId > 0)
-					{
-						// Get entity pointer
-						pEntity = FNullEnt(INDEXENT(EntityId)) ? INDEXENT(EntityId) : nullptr;
-					}
+          // If has entity index
+          if (EntityId > 0) {
+            // Get entity pointer
+            pEntity =
+                FNullEnt(INDEXENT(EntityId)) ? INDEXENT(EntityId) : nullptr;
+          }
 
-					// If is not empty
-					if (!Message.empty())
-					{
-						// Print to entity
-						gLogUtil.SayText(pEntity, ENTINDEX(pEntity), Message.c_str());
-					}
-				}
-			}
-		}
-		catch (const nlohmann::ordered_json::exception& e)
-		{
-			LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
-		}
-	}
+          // If is not empty
+          if (!Message.empty()) {
+            // Print to entity
+            gLogUtil.SayText(pEntity, ENTINDEX(pEntity), Message.c_str());
+          }
+        }
+      }
+    } catch (const nlohmann::ordered_json::exception &e) {
+      LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
+    }
+  }
 }
 
 // Print to hudmessage chat from result
-void CLogApi::ShowHudMessage(int EventIndex, nlohmann::ordered_json Data)
-{
-	// If is not empty
-	if (!Data[__func__].empty())
-	{
-		try
-		{
-			if (Data[__func__].is_object())
-			{
-				// If is not empty
-				if (!Data[__func__]["EntityId"].empty() && !Data[__func__]["TeamSay"].empty() && !Data[__func__]["Message"].empty())
-				{
-					// Entity index
-					auto EntityId = Data[__func__]["EntityId"].get<int>();
+void CLogApi::ShowHudMessage(int EventIndex, nlohmann::ordered_json Data) {
+  // If is not empty
+  if (!Data[__func__].empty()) {
+    try {
+      if (Data[__func__].is_object()) {
+        // If is not empty
+        if (!Data[__func__]["EntityId"].empty() &&
+            !Data[__func__]["TeamSay"].empty() &&
+            !Data[__func__]["Message"].empty()) {
+          // Entity index
+          auto EntityId = Data[__func__]["EntityId"].get<int>();
 
-					// TeamSay (false Center message, true Left message)
-					auto TeamSay = Data[__func__]["TeamSay"].get<bool>();
+          // TeamSay (false Center message, true Left message)
+          auto TeamSay = Data[__func__]["TeamSay"].get<bool>();
 
-					// Get message string
-					auto Message = Data[__func__]["Message"].get<std::string>();
+          // Get message string
+          auto Message = Data[__func__]["Message"].get<std::string>();
 
-					// Entity pointer
-					edict_t* pEntity = nullptr;
+          // Entity pointer
+          edict_t *pEntity = nullptr;
 
-					// If has entity index
-					if (EntityId > 0)
-					{
-						// Get entity pointer
-						pEntity = FNullEnt(INDEXENT(EntityId)) ? INDEXENT(EntityId) : nullptr;
-					}
+          // If has entity index
+          if (EntityId > 0) {
+            // Get entity pointer
+            pEntity =
+                FNullEnt(INDEXENT(EntityId)) ? INDEXENT(EntityId) : nullptr;
+          }
 
-					// If is not empty
-					if (!Message.empty())
-					{
-						// Print to entity
-						gLogUtil.HudMessage(pEntity, gLogCommand.GetHudParameters(TeamSay), "%s", Message.c_str());
-					}
-				}
-			}
-		}
-		catch (const nlohmann::ordered_json::exception& e)
-		{
-			LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
-		}
-	}
+          // If is not empty
+          if (!Message.empty()) {
+            // Print to entity
+            gLogUtil.HudMessage(pEntity, gLogCommand.GetHudParameters(TeamSay),
+                                "%s", Message.c_str());
+          }
+        }
+      }
+    } catch (const nlohmann::ordered_json::exception &e) {
+      LOG_CONSOLE(PLID, "[%s] %s", __func__, e.what());
+    }
+  }
 }
 
 // Get server info as JSON data
-nlohmann::ordered_json CLogApi::GetServerInfo()
-{
-	// Json
-	nlohmann::ordered_json ServerInfo;
+nlohmann::ordered_json CLogApi::GetServerInfo() {
+  // Json
+  nlohmann::ordered_json ServerInfo;
 
-	// Set address
-	ServerInfo["Address"] = g_engfuncs.pfnCVarGetString("net_address");
+  // Set address
+  ServerInfo["Address"] = g_engfuncs.pfnCVarGetString("net_address");
 
-	// Set hostname
-	ServerInfo["Hostname"] = g_engfuncs.pfnCVarGetString("hostname");
+  // Set hostname
+  ServerInfo["Hostname"] = g_engfuncs.pfnCVarGetString("hostname");
 
-	// Set map name
-	ServerInfo["Map"] = STRING(gpGlobals->mapname);
+  // Set map name
+  ServerInfo["Map"] = STRING(gpGlobals->mapname);
 
-	// Set game
-	ServerInfo["Game"] = "Counter-Strike";
+  // Set game
+  ServerInfo["Game"] = "Counter-Strike";
 
-	// If CSGameRules is not null
-	if (g_pGameRules)
-	{
-		// If server has game description
-		if (CSGameRules()->m_GameDesc)
-		{
-			// If is not empty
-			if (CSGameRules()->m_GameDesc[0u] != '\0')
-			{
-				// Set game description name
-				ServerInfo["Game"] = CSGameRules()->m_GameDesc;
-			}
-		}
-	}
+  // If CSGameRules is not null
+  if (g_pGameRules) {
+    // If server has game description
+    if (CSGameRules()->m_GameDesc) {
+      // If is not empty
+      if (CSGameRules()->m_GameDesc[0u] != '\0') {
+        // Set game description name
+        ServerInfo["Game"] = CSGameRules()->m_GameDesc;
+      }
+    }
+  }
 
-	// Set max players
-	ServerInfo["MaxPlayers"] = gpGlobals->maxClients;
+  // Set max players
+  ServerInfo["MaxPlayers"] = gpGlobals->maxClients;
 
-	// Players
-	auto Players = gLogPlayer.GetPlayers();
+  // Players
+  auto Players = gLogPlayer.GetPlayers();
 
-	// If player list is not empty
-	if (!Players.empty())
-	{
-		// Loop players
-		for (auto const& Player : Players)
-		{
-			// Set player information
-			ServerInfo["Players"][Player.first] =
-			{
-				{"EntityId", Player.second.EntityId},
-				{"Auth", Player.first},
-				{"Name", Player.second.Name},
-				{"Address", Player.second.Address},
-				{"UserId", Player.second.UserId},
-				{"Team", Player.second.Team},
-				{"Frags", Player.second.Frags},
-				{"Deaths", Player.second.Deaths},
-				{"GameTime", Player.second.GameTime},
-				{"ConnectTime", Player.second.ConnectTime}
-			};
-		}
-	}
+  // If player list is not empty
+  if (!Players.empty()) {
+    // Loop players
+    for (auto const &Player : Players) {
+      // Set player information
+      ServerInfo["Players"][Player.first] = {
+          {"EntityId", Player.second.EntityId},
+          {"Auth", Player.first},
+          {"Name", Player.second.Name},
+          {"Address", Player.second.Address},
+          {"UserId", Player.second.UserId},
+          {"Team", Player.second.Team},
+          {"Frags", Player.second.Frags},
+          {"Deaths", Player.second.Deaths},
+          {"GameTime", Player.second.GameTime},
+          {"ConnectTime", Player.second.ConnectTime}};
+    }
+  }
 
-	// Return JSON data
-	return ServerInfo;
+  // Return JSON data
+  return ServerInfo;
 }

--- a/LogApi/LogCommand.cpp
+++ b/LogApi/LogCommand.cpp
@@ -3,232 +3,208 @@
 CLogCommand gLogCommand;
 
 // On Server Activate
-void CLogCommand::ServerActivate()
-{
-	// Clear hud line
-	this->m_HudLine = 0;
-	
-	// Register server commands
-	g_engfuncs.pfnAddServerCommand("log_say", this->Say);
-	g_engfuncs.pfnAddServerCommand("log_tsay", this->TeamSay);
-	g_engfuncs.pfnAddServerCommand("log_csay", this->CenterSay);
-	g_engfuncs.pfnAddServerCommand("log_psay", this->PrivateSay);
-	g_engfuncs.pfnAddServerCommand("log_console", this->ConsoleLog);
-	g_engfuncs.pfnAddServerCommand("log_motd", this->OpenMotd);
-	g_engfuncs.pfnAddServerCommand("log_send_info", this->ServerInfo);
+void CLogCommand::ServerActivate() {
+  // Clear hud line
+  this->m_HudLine = 0;
+
+  // Register server commands
+  g_engfuncs.pfnAddServerCommand("log_say", this->Say);
+  g_engfuncs.pfnAddServerCommand("log_tsay", this->TeamSay);
+  g_engfuncs.pfnAddServerCommand("log_csay", this->CenterSay);
+  g_engfuncs.pfnAddServerCommand("log_psay", this->PrivateSay);
+  g_engfuncs.pfnAddServerCommand("log_console", this->ConsoleLog);
+  g_engfuncs.pfnAddServerCommand("log_motd", this->OpenMotd);
+  g_engfuncs.pfnAddServerCommand("log_send_info", this->ServerInfo);
 }
 
 // Say
-void CLogCommand::Say()
-{
-	if (g_engfuncs.pfnCmd_Argc() >= 2)
-	{
-		auto Message = g_engfuncs.pfnCmd_Args();
+void CLogCommand::Say() {
+  if (g_engfuncs.pfnCmd_Argc() >= 2) {
+    auto Message = g_engfuncs.pfnCmd_Args();
 
-		if (Message)
-		{
-			if (Message[0u] != '\0')
-			{
-				gLogUtil.SayText(nullptr, PRINT_TEAM_DEFAULT, "%s", Message);
-				return;
-			}
-		}
-	}
+    if (Message) {
+      if (Message[0u] != '\0') {
+        gLogUtil.SayText(nullptr, PRINT_TEAM_DEFAULT, "%s", Message);
+        return;
+      }
+    }
+  }
 
-	LOG_CONSOLE(PLID, "[%s] Usage: log_say <message>", Plugin_info.logtag);
+  LOG_CONSOLE(PLID, "[%s] Usage: log_say <message>", Plugin_info.logtag);
 }
 
 // Team Say
-void CLogCommand::TeamSay()
-{
-	if (g_engfuncs.pfnCmd_Argc() >= 2)
-	{
-		auto Message = g_engfuncs.pfnCmd_Args();
+void CLogCommand::TeamSay() {
+  if (g_engfuncs.pfnCmd_Argc() >= 2) {
+    auto Message = g_engfuncs.pfnCmd_Args();
 
-		if (Message)
-		{
-			if (Message[0u] != '\0')
-			{
-				gLogUtil.HudMessage(nullptr, gLogCommand.GetHudParameters(true), "%s", Message);
-				return;
-			}
-		}
-	}
+    if (Message) {
+      if (Message[0u] != '\0') {
+        gLogUtil.HudMessage(nullptr, gLogCommand.GetHudParameters(true), "%s",
+                            Message);
+        return;
+      }
+    }
+  }
 
-	LOG_CONSOLE(PLID, "[%s] Usage: log_tsay <message>", Plugin_info.logtag);
+  LOG_CONSOLE(PLID, "[%s] Usage: log_tsay <message>", Plugin_info.logtag);
 }
 
 // Center Say
-void CLogCommand::CenterSay()
-{
-	if (g_engfuncs.pfnCmd_Argc() >= 2)
-	{
-		auto Message = g_engfuncs.pfnCmd_Args();
+void CLogCommand::CenterSay() {
+  if (g_engfuncs.pfnCmd_Argc() >= 2) {
+    auto Message = g_engfuncs.pfnCmd_Args();
 
-		if (Message)
-		{
-			if (Message[0u] != '\0')
-			{
-				gLogUtil.HudMessage(nullptr, gLogCommand.GetHudParameters(false), "%s", Message);
-				return;
-			}
-		}
-	}
+    if (Message) {
+      if (Message[0u] != '\0') {
+        gLogUtil.HudMessage(nullptr, gLogCommand.GetHudParameters(false), "%s",
+                            Message);
+        return;
+      }
+    }
+  }
 
-	LOG_CONSOLE(PLID, "[%s] Usage: log_csay <message>", Plugin_info.logtag);
+  LOG_CONSOLE(PLID, "[%s] Usage: log_csay <message>", Plugin_info.logtag);
 }
 
 // Private Say
-void CLogCommand::PrivateSay()
-{
-	if (g_engfuncs.pfnCmd_Argc() >= 3)
-	{
-		std::string Target = g_engfuncs.pfnCmd_Argv(1);
+void CLogCommand::PrivateSay() {
+  if (g_engfuncs.pfnCmd_Argc() >= 3) {
+    std::string Target = g_engfuncs.pfnCmd_Argv(1);
 
-		if (!Target.empty())
-		{
-			if (Target.length() > 1)
-			{
-				std::string Message = g_engfuncs.pfnCmd_Args();
+    if (!Target.empty()) {
+      if (Target.length() > 1) {
+        std::string Message = g_engfuncs.pfnCmd_Args();
 
-				if (!Message.empty())
-				{
-					if (Message.length() > 0)
-					{
-						auto Player = gLogUtil.FindPlayer(Target);
+        if (!Message.empty()) {
+          if (Message.length() > 0) {
+            auto Player = gLogUtil.FindPlayer(Target);
 
-						if (Player)
-						{
-							Message.erase(0, Target.length() + 1);
+            if (Player) {
+              if (Message.length() > Target.length()) {
+                Message.erase(0, Target.length() + 1);
+                gLogUtil.SayText(Player->edict(), Player->entindex(), "%s",
+                                 Message.c_str());
+              }
+            } else {
+              LOG_CONSOLE(
+                  PLID, "[%s] Client with that name or userid '%s' not found.",
+                  Plugin_info.logtag, Target.c_str());
+            }
 
-							gLogUtil.SayText(Player->edict(), Player->entindex(), "%s", Message.c_str());
-						}
-						else
-						{
-							LOG_CONSOLE(PLID, "[%s] Client with that name or userid '%s' not found.", Plugin_info.logtag, Target.c_str());
-						}
+            return;
+          }
+        }
+      }
+    }
+  }
 
-						return;
-					}
-				}
-			}
-		}
-	}
-
-	LOG_CONSOLE(PLID, "[%s] Usage: log_psay <name or #userid> <message>", Plugin_info.logtag);
+  LOG_CONSOLE(PLID, "[%s] Usage: log_psay <name or #userid> <message>",
+              Plugin_info.logtag);
 }
 
 // Console Log
-void CLogCommand::ConsoleLog()
-{
-	if (g_engfuncs.pfnCmd_Argc() >= 3)
-	{
-		std::string Target = g_engfuncs.pfnCmd_Argv(1);
+void CLogCommand::ConsoleLog() {
+  if (g_engfuncs.pfnCmd_Argc() >= 3) {
+    std::string Target = g_engfuncs.pfnCmd_Argv(1);
 
-		if (!Target.empty())
-		{
-			if (Target.length() > 1)
-			{
-				std::string Message = g_engfuncs.pfnCmd_Args();
+    if (!Target.empty()) {
+      if (Target.length() > 1) {
+        std::string Message = g_engfuncs.pfnCmd_Args();
 
-				if (!Message.empty())
-				{
-					if (Message.length() > 0)
-					{
-						auto Player = gLogUtil.FindPlayer(Target);
+        if (!Message.empty()) {
+          if (Message.length() > 0) {
+            auto Player = gLogUtil.FindPlayer(Target);
 
-						if (Player)
-						{
-							Message.erase(0, Target.length() + 1);
+            if (Player) {
+              if (Message.length() > Target.length()) {
+                Message.erase(0, Target.length() + 1);
+                gLogUtil.ClientPrint(Player->edict(), PRINT_CONSOLE, "%s",
+                                     Message.c_str());
+              }
+            } else {
+              LOG_CONSOLE(
+                  PLID, "[%s] Client with that name or userid '%s' not found.",
+                  Plugin_info.logtag, Target.c_str());
+            }
 
-							gLogUtil.ClientPrint(Player->edict(), PRINT_CONSOLE, "%s", Message.c_str());
-						}
-						else
-						{
-							LOG_CONSOLE(PLID, "[%s] Client with that name or userid '%s' not found.", Plugin_info.logtag, Target.c_str());
-						}
+            return;
+          }
+        }
+      }
+    }
+  }
 
-						return;
-					}
-				}
-			}
-		}
-	}
-
-	LOG_CONSOLE(PLID, "[%s] Usage: log_console <name or #userid> <message>", Plugin_info.logtag);
+  LOG_CONSOLE(PLID, "[%s] Usage: log_console <name or #userid> <message>",
+              Plugin_info.logtag);
 }
 
 // Open MOTD
-void CLogCommand::OpenMotd()
-{
-	if (g_engfuncs.pfnCmd_Argc() >= 3)
-	{
-		std::string Target = g_engfuncs.pfnCmd_Argv(1);
+void CLogCommand::OpenMotd() {
+  if (g_engfuncs.pfnCmd_Argc() >= 3) {
+    std::string Target = g_engfuncs.pfnCmd_Argv(1);
 
-		if (!Target.empty())
-		{
-			if (Target.length() > 1)
-			{
-				std::string Message = g_engfuncs.pfnCmd_Args();
+    if (!Target.empty()) {
+      if (Target.length() > 1) {
+        std::string Message = g_engfuncs.pfnCmd_Args();
 
-				if (!Message.empty())
-				{
-					if (Message.length() > 0)
-					{
-						auto Player = gLogUtil.FindPlayer(Target);
+        if (!Message.empty()) {
+          if (Message.length() > 0) {
+            auto Player = gLogUtil.FindPlayer(Target);
 
-						if (Player)
-						{
-							Message.erase(0, Target.length() + 1);
+            if (Player) {
+              if (Message.length() > Target.length()) {
+                Message.erase(0, Target.length() + 1);
 
-							char Path[MAX_MOTD_LENGTH] = { 0 };
+                char Path[MAX_MOTD_LENGTH] = {0};
 
-							Q_memset(Path, 0, sizeof(Path));
+                Q_memset(Path, 0, sizeof(Path));
 
-							Q_strncpy(Path, Message.data(), sizeof(Path));
+                Q_strncpy(Path, Message.data(), sizeof(Path));
 
-							gLogUtil.ShowMotd(Player->edict(), Path, strlen(Path));
+                gLogUtil.ShowMotd(Player->edict(), Path, strlen(Path));
+              }
 
-							return;
-						}
-						else
-						{
-							LOG_CONSOLE(PLID, "[%s] Client with that name or userid '%s' not found.", Plugin_info.logtag, Target.c_str());
-						}
+              return;
+            } else {
+              LOG_CONSOLE(
+                  PLID, "[%s] Client with that name or userid '%s' not found.",
+                  Plugin_info.logtag, Target.c_str());
+            }
 
-						return;
-					}
-				}
-			}
-		}
-	}
+            return;
+          }
+        }
+      }
+    }
+  }
 
-	LOG_CONSOLE(PLID, "[%s] Usage: log_motd <name or #userid> <webpage or file name>", Plugin_info.logtag);
+  LOG_CONSOLE(PLID,
+              "[%s] Usage: log_motd <name or #userid> <webpage or file name>",
+              Plugin_info.logtag);
 }
 
 // Send Server Information
-void CLogCommand::ServerInfo()
-{
-	gLogEvent.ServerInfo();
+void CLogCommand::ServerInfo() {
+  gLogEvent.ServerInfo();
 
-	LOG_CONSOLE(PLID, "[%s] Server info sent to webserver.", Plugin_info.logtag);
+  LOG_CONSOLE(PLID, "[%s] Server info sent to webserver.", Plugin_info.logtag);
 }
 
 // Get Hudmessage Parameters
-hudtextparms_t CLogCommand::GetHudParameters(bool TeamSay)
-{
-	hudtextparms_t hud = { -1.0f, -1.0f, 1, 255, 255, 255, 255, 0, 255, 0, 255, 0.5f, 0.5f, 6.0f, 6.0f, -1 };
+hudtextparms_t CLogCommand::GetHudParameters(bool TeamSay) {
+  hudtextparms_t hud = {-1.0f, -1.0f, 1,   255,  255,  255,  255,  0,
+                        255,   0,     255, 0.5f, 0.5f, 6.0f, 6.0f, -1};
 
-	if (++this->m_HudLine > 6 || this->m_HudLine < 3)
-	{
-		this->m_HudLine = 3;
-	}
+  if (++this->m_HudLine > 6 || this->m_HudLine < 3) {
+    this->m_HudLine = 3;
+  }
 
-	hud.x = TeamSay ? 0.05 : -1.0;
+  hud.x = TeamSay ? 0.05 : -1.0;
 
-	hud.y = ((TeamSay ? 0.55f : 0.1f) + float(this->m_HudLine) / 30.0f);
+  hud.y = ((TeamSay ? 0.55f : 0.1f) + float(this->m_HudLine) / 30.0f);
 
-	hud.channel = (this->m_HudLine - 2);
+  hud.channel = (this->m_HudLine - 2);
 
-	return hud;
+  return hud;
 }

--- a/LogApi/LogCurl.cpp
+++ b/LogApi/LogCurl.cpp
@@ -2,139 +2,145 @@
 
 CLogCurl gLogCurl;
 
-void CLogCurl::ServerActivate()
-{
-	if (!this->m_MultiHandle)
-	{
-		this->m_RequestIndex = 0;
+void CLogCurl::ServerActivate() {
+  if (!this->m_MultiHandle) {
+    this->m_RequestIndex = 0;
 
-		this->m_Data.clear();
+    this->m_Data.clear();
 
-		curl_global_init(CURL_GLOBAL_ALL);
+    curl_global_init(CURL_GLOBAL_ALL);
 
-		this->m_MultiHandle = curl_multi_init();
-	}
+    this->m_MultiHandle = curl_multi_init();
+  }
 }
 
-void CLogCurl::ServerFrame()
-{
-	if (this->m_MultiHandle)
-	{
-		int HandleCount = 0;
+void CLogCurl::ServerFrame() {
+  if (this->m_MultiHandle) {
+    int HandleCount = 0;
+    int ProcessedThisFrame = 0;
 
-		CURLMsg* MsgInfo = NULL;
+    CURLMsg *MsgInfo = NULL;
 
-		do
-		{
-			curl_multi_perform(this->m_MultiHandle, &HandleCount);
+    curl_multi_perform(this->m_MultiHandle, &HandleCount);
 
-			while (MsgInfo = curl_multi_info_read(this->m_MultiHandle, &HandleCount))
-			{
-				if (MsgInfo->msg == CURLMSG_DONE)
-				{
-					int Index = 0;
+    while (ProcessedThisFrame < 5 && (MsgInfo = curl_multi_info_read(
+                                          this->m_MultiHandle, &HandleCount))) {
+      if (MsgInfo->msg == CURLMSG_DONE) {
+        int Index = 0;
 
-					curl_easy_getinfo(MsgInfo->easy_handle, CURLINFO_PRIVATE, &Index);
+        curl_easy_getinfo(MsgInfo->easy_handle, CURLINFO_PRIVATE, &Index);
 
-					if (this->m_Data.find(Index) != this->m_Data.end())
-					{
-						gLogApi.CallbackResult(MsgInfo->easy_handle, this->m_Data[Index].Size, this->m_Data[Index].Memory, this->m_Data[Index].EventIndex);
+        if (this->m_Data.find(Index) != this->m_Data.end()) {
+          gLogApi.CallbackResult(MsgInfo->easy_handle, this->m_Data[Index].Size,
+                                 this->m_Data[Index].Memory,
+                                 this->m_Data[Index].EventIndex);
 
-						this->m_Data.erase(Index);
-					}
+          free(this->m_Data[Index].Memory);
 
-					curl_multi_remove_handle(this->m_MultiHandle, MsgInfo->easy_handle);
+          if (this->m_Data[Index].Headers) {
+            curl_slist_free_all(this->m_Data[Index].Headers);
+          }
 
-					curl_easy_cleanup(MsgInfo->easy_handle);
-				}
-			}
-		}
-		while (HandleCount);
-	}
+          this->m_Data.erase(Index);
+        }
+
+        curl_multi_remove_handle(this->m_MultiHandle, MsgInfo->easy_handle);
+
+        curl_easy_cleanup(MsgInfo->easy_handle);
+
+        ProcessedThisFrame++;
+      }
+    }
+  }
 }
 
-void CLogCurl::PostJSON(const char* url, long Timeout, std::string BearerToken, std::string PostData, int EventIndex)
-{
-	if (this->m_MultiHandle)
-	{
-		if (url)
-		{
-			CURL* ch = curl_easy_init();
+void CLogCurl::PostJSON(const char *url, long Timeout, std::string BearerToken,
+                        std::string PostData, int EventIndex) {
+  if (this->m_MultiHandle) {
+    if (url) {
+      CURL *ch = curl_easy_init();
 
-			if (ch)
-			{
-				this->m_Data[this->m_RequestIndex] = { 0 };
+      if (ch) {
+        this->m_Data[this->m_RequestIndex] = {0};
 
-				this->m_Data[this->m_RequestIndex].EventIndex = EventIndex;
+        this->m_Data[this->m_RequestIndex].EventIndex = EventIndex;
+        this->m_Data[this->m_RequestIndex].Headers = NULL;
 
-				curl_easy_setopt(ch, CURLOPT_URL, url);
+        curl_easy_setopt(ch, CURLOPT_URL, url);
 
-				curl_easy_setopt(ch, CURLOPT_TIMEOUT, (Timeout) > 0 ? Timeout : 5);
+        curl_easy_setopt(ch, CURLOPT_TIMEOUT, (Timeout) > 0 ? Timeout : 5);
 
-				curl_easy_setopt(ch, CURLOPT_FOLLOWLOCATION, 1L);
+        curl_easy_setopt(ch, CURLOPT_FOLLOWLOCATION, 1L);
 
-				curl_easy_setopt(ch, CURLOPT_WRITEFUNCTION, this->WriteMemoryCallback);
+        curl_easy_setopt(ch, CURLOPT_WRITEFUNCTION, this->WriteMemoryCallback);
 
-				curl_easy_setopt(ch, CURLOPT_NOPROGRESS, 1L);
+        curl_easy_setopt(ch, CURLOPT_NOPROGRESS, 1L);
 
-				curl_easy_setopt(ch, CURLOPT_POST, 1L);
+        curl_easy_setopt(ch, CURLOPT_POST, 1L);
 
-				curl_easy_setopt(ch, CURLOPT_POSTFIELDSIZE, (long)PostData.size());
+        curl_easy_setopt(ch, CURLOPT_POSTFIELDSIZE, (long)PostData.size());
 
-				curl_easy_setopt(ch, CURLOPT_COPYPOSTFIELDS, PostData.c_str());
+        curl_easy_setopt(ch, CURLOPT_COPYPOSTFIELDS, PostData.c_str());
 
-				struct curl_slist* chHeaders = curl_slist_append(NULL, "Content-Type: application/json");
+        struct curl_slist *chHeaders =
+            curl_slist_append(NULL, "Content-Type: application/json");
 
-				if (BearerToken.length() > 0) 
-				{
-					std::string AuthorizationHeader = "Authorization: Bearer " + BearerToken;
+        if (BearerToken.length() > 0) {
+          std::string AuthorizationHeader =
+              "Authorization: Bearer " + BearerToken;
 
-					chHeaders = curl_slist_append(chHeaders, AuthorizationHeader.c_str());
-				}
+          chHeaders = curl_slist_append(chHeaders, AuthorizationHeader.c_str());
+        }
 
-				curl_easy_setopt(ch, CURLOPT_HTTPHEADER, chHeaders);
+        curl_easy_setopt(ch, CURLOPT_HTTPHEADER, chHeaders);
 
-				curl_easy_setopt(ch, CURLOPT_WRITEDATA, (void*)&this->m_Data[this->m_RequestIndex]);
+        this->m_Data[this->m_RequestIndex].Headers = chHeaders;
 
-				curl_easy_setopt(ch, CURLOPT_PRIVATE, this->m_RequestIndex);
+        curl_easy_setopt(ch, CURLOPT_SSL_VERIFYPEER, 1L);
+        curl_easy_setopt(ch, CURLOPT_SSL_VERIFYHOST, 2L);
 
-				curl_multi_add_handle(this->m_MultiHandle, ch);
+        curl_easy_setopt(ch, CURLOPT_WRITEDATA,
+                         (void *)&this->m_Data[this->m_RequestIndex]);
 
-				this->m_RequestIndex++;
-			}
-		}
-	}
+        curl_easy_setopt(ch, CURLOPT_PRIVATE, this->m_RequestIndex);
+
+        curl_multi_add_handle(this->m_MultiHandle, ch);
+
+        this->m_RequestIndex++;
+
+        if (this->m_RequestIndex < 0) {
+          this->m_RequestIndex = 1;
+        }
+      }
+    }
+  }
 }
 
-size_t CLogCurl::WriteMemoryCallback(void* contents, size_t size, size_t nmemb, void* userp)
-{
-	if (contents)
-	{
-		if (userp)
-		{
-			size_t realsize = size * nmemb;
+size_t CLogCurl::WriteMemoryCallback(void *contents, size_t size, size_t nmemb,
+                                     void *userp) {
+  if (contents) {
+    if (userp) {
+      size_t realsize = size * nmemb;
 
-			if (realsize > 0)
-			{
-				P_CURL_MOD_MEMORY* mem = (P_CURL_MOD_MEMORY*)userp;
-			
-				char* ptr = (char*)realloc(mem->Memory, mem->Size + realsize + 1);
-			
-				if (ptr)
-				{
-					mem->Memory = ptr;
-			
-					memcpy(&(mem->Memory[mem->Size]), contents, realsize);
-			
-					mem->Size += realsize;
-			
-					mem->Memory[mem->Size] = 0;
-			
-					return realsize;
-				}
-			}
-		}
-	}
+      if (realsize > 0) {
+        P_CURL_MOD_MEMORY *mem = (P_CURL_MOD_MEMORY *)userp;
 
-	return 0;
+        char *ptr = (char *)realloc(mem->Memory, mem->Size + realsize + 1);
+
+        if (ptr) {
+          mem->Memory = ptr;
+
+          memcpy(&(mem->Memory[mem->Size]), contents, realsize);
+
+          mem->Size += realsize;
+
+          mem->Memory[mem->Size] = 0;
+
+          return realsize;
+        }
+      }
+    }
+  }
+
+  return 0;
 }

--- a/LogApi/LogCurl.h
+++ b/LogApi/LogCurl.h
@@ -1,28 +1,29 @@
 #pragma once
 
-struct P_CURL_MOD_MEMORY
-{
-	char* Memory;
-	size_t Size;
-	int EventIndex;
+struct P_CURL_MOD_MEMORY {
+  char *Memory;
+  size_t Size;
+  int EventIndex;
+  struct curl_slist *Headers;
 };
 
-class CLogCurl
-{
+class CLogCurl {
 public:
-	void ServerActivate();
-	void ServerFrame();
+  void ServerActivate();
+  void ServerFrame();
 
-	void PostJSON(const char* url, long Timeout, std::string BearerToken, std::string PostData, int EventIndex);
+  void PostJSON(const char *url, long Timeout, std::string BearerToken,
+                std::string PostData, int EventIndex);
 
-	static size_t WriteMemoryCallback(void* contents, size_t size, size_t nmemb, void* userp);
+  static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb,
+                                    void *userp);
 
 private:
-	CURLM* m_MultiHandle = NULL;
+  CURLM *m_MultiHandle = NULL;
 
-	long m_RequestIndex = 0;
+  long m_RequestIndex = 0;
 
-	std::map<long, P_CURL_MOD_MEMORY> m_Data;
+  std::map<long, P_CURL_MOD_MEMORY> m_Data;
 };
 
 extern CLogCurl gLogCurl;

--- a/LogApi/LogCvar.cpp
+++ b/LogApi/LogCvar.cpp
@@ -20,6 +20,9 @@ void CLogCvar::ServerActivate()
 	// // Server Info Event Delay (Delay to update Server Info on webserver)
 	this->m_Delay = this->Register("log_api_delay", "60.0");
 
+	// // Enable Remote Command Execution (0 Disable, 1 Enable)
+	this->m_ExecCommands = this->Register("log_api_exec_commands", "0");
+
 	// // Execute Settings File
 	g_engfuncs.pfnServerCommand("exec addons/logapi/logapi.cfg\n");
 

--- a/LogApi/LogCvar.h
+++ b/LogApi/LogCvar.h
@@ -1,23 +1,23 @@
 #pragma once
 
-class CLogCvar
-{
+class CLogCvar {
 public:
-    // On Server Activate
-    void ServerActivate();
+  // On Server Activate
+  void ServerActivate();
 
-    // Register Cvar
-    cvar_t* Register(const char *pszName, const char *pszValue);
+  // Register Cvar
+  cvar_t *Register(const char *pszName, const char *pszValue);
 
-	// Console variables
-	cvar_t* m_Enable;
-	cvar_t* m_Address;
-	cvar_t* m_Timeout;
-	cvar_t* m_Bearer;
-	cvar_t* m_Delay;
+  // Console variables
+  cvar_t *m_Enable;
+  cvar_t *m_Address;
+  cvar_t *m_Timeout;
+  cvar_t *m_Bearer;
+  cvar_t *m_Delay;
+  cvar_t *m_ExecCommands;
 
-    // Public cvar data
-    std::map<std::string, cvar_t> m_Data;
+  // Public cvar data
+  std::map<std::string, cvar_t> m_Data;
 };
 
 extern CLogCvar gLogCvar;

--- a/LogApi/LogPlayer.cpp
+++ b/LogApi/LogPlayer.cpp
@@ -2,159 +2,141 @@
 
 CLogPlayer gLogPlayer;
 
-void CLogPlayer::Connect(edict_t* pEdict, const char* pszName, const char* pszAddress)
-{
-	if (!FNullEnt(pEdict))
-	{
-		auto Auth = gLogUtil.GetAuthId(pEdict);
+void CLogPlayer::Connect(edict_t *pEdict, const char *pszName,
+                         const char *pszAddress) {
+  if (!FNullEnt(pEdict)) {
+    auto Auth = gLogUtil.GetAuthId(pEdict);
 
-		if (Auth)
-		{
-			this->m_Players[Auth].Auth = Auth;
+    if (Auth) {
+      this->m_Players[Auth].Auth = Auth;
 
-			if (pszName)
-			{
-				if (pszName[0u] != '\0')
-				{
-					this->m_Players[Auth].Name = pszName;
-				}
-			}
+      if (pszName) {
+        if (pszName[0u] != '\0') {
+          this->m_Players[Auth].Name = pszName;
+        }
+      }
 
-			if (pszAddress)
-			{
-				if (pszAddress[0u] != '\0')
-				{
-					this->m_Players[Auth].Address = pszAddress;
-				}
-			}
+      if (pszAddress) {
+        if (pszAddress[0u] != '\0') {
+          this->m_Players[Auth].Address = pszAddress;
+        }
+      }
 
-			this->m_Players[Auth].EntityId = ENTINDEX(pEdict);
+      this->m_Players[Auth].EntityId = ENTINDEX(pEdict);
 
-			this->m_Players[Auth].UserId = g_engfuncs.pfnGetPlayerUserId(pEdict);
+      this->m_Players[Auth].UserId = g_engfuncs.pfnGetPlayerUserId(pEdict);
 
-			this->m_Players[Auth].Team = pEdict->v.team;
+      this->m_Players[Auth].Team = pEdict->v.team;
 
-			this->m_Players[Auth].Frags = pEdict->v.frags;
+      this->m_Players[Auth].Frags = pEdict->v.frags;
 
-			this->m_Players[Auth].Deaths = 0;
+      this->m_Players[Auth].Deaths = 0;
 
-			this->m_Players[Auth].GameTime = 0.0f;
+      this->m_Players[Auth].GameTime = 0.0f;
 
-			this->m_Players[Auth].ConnectTime = gpGlobals->time;
-		}
-	}
+      this->m_Players[Auth].ConnectTime = gpGlobals->time;
+    }
+  }
 }
 
-void CLogPlayer::Disconnect(edict_t* pEdict)
-{
-	if (!FNullEnt(pEdict))
-	{
-		auto Auth = gLogUtil.GetAuthId(pEdict);
+void CLogPlayer::Disconnect(edict_t *pEdict) {
+  if (!FNullEnt(pEdict)) {
+    auto Auth = gLogUtil.GetAuthId(pEdict);
 
-		if (Auth)
-		{
-			if (this->m_Players.find(Auth) != this->m_Players.end())
-			{
-				this->m_Players.erase(Auth);
-			}
-		}
-	}
+    if (Auth) {
+      if (this->m_Players.find(Auth) != this->m_Players.end()) {
+        this->m_Players.erase(Auth);
+      }
+    }
+  }
 }
 
-void CLogPlayer::Update(edict_t* pEdict)
-{
-	if (!FNullEnt(pEdict))
-	{
-		auto Auth = gLogUtil.GetAuthId(pEdict);
+void CLogPlayer::Update(edict_t *pEdict) {
+  if (!FNullEnt(pEdict)) {
+    auto Auth = gLogUtil.GetAuthId(pEdict);
 
-		if (Auth)
-		{
-			this->m_Players[Auth].EntityId = ENTINDEX(pEdict);
+    if (Auth) {
+      for (auto it = this->m_Players.begin(); it != this->m_Players.end();) {
+        if (it->second.EntityId == ENTINDEX(pEdict) && it->first != Auth) {
+          it = this->m_Players.erase(it);
+        } else {
+          ++it;
+        }
+      }
 
-			this->m_Players[Auth].Auth = Auth;
+      this->m_Players[Auth].EntityId = ENTINDEX(pEdict);
 
-			this->m_Players[Auth].Name = STRING(pEdict->v.netname);
+      this->m_Players[Auth].Auth = Auth;
 
-			this->m_Players[Auth].UserId = g_engfuncs.pfnGetPlayerUserId(pEdict);
+      this->m_Players[Auth].Name = STRING(pEdict->v.netname);
 
-			auto Player = UTIL_PlayerByIndexSafe(ENTINDEX(pEdict));
+      this->m_Players[Auth].UserId = g_engfuncs.pfnGetPlayerUserId(pEdict);
 
-			if (Player)
-			{
-				this->m_Players[Auth].Team = static_cast<int>(Player->m_iTeam);
+      auto Player = UTIL_PlayerByIndexSafe(ENTINDEX(pEdict));
 
-				this->m_Players[Auth].Frags = pEdict->v.frags;
+      if (Player) {
+        this->m_Players[Auth].Team = static_cast<int>(Player->m_iTeam);
 
-				this->m_Players[Auth].Deaths = Player->m_iDeaths;
+        this->m_Players[Auth].Frags = pEdict->v.frags;
 
-				if (this->m_Players[Auth].GameTime <= 0.0f)
-				{
-					if (Player->m_iTeam == UNASSIGNED)
-					{
-						if (!Player->IsBot())
-						{
-							gLogUtil.TeamInfo(Player->edict(), MAX_CLIENTS + TERRORIST + 1, "TERRORIST");
-							gLogUtil.TeamInfo(Player->edict(), MAX_CLIENTS + CT + 1, "CT");
-						}
-					}
-				}
-			}
+        this->m_Players[Auth].Deaths = Player->m_iDeaths;
 
-			if (this->m_Players[Auth].ConnectTime <= 0.0f)
-			{
-				this->m_Players[Auth].ConnectTime = gpGlobals->time;
-			}
+        if (this->m_Players[Auth].GameTime <= 0.0f) {
+          if (Player->m_iTeam == UNASSIGNED) {
+            if (!Player->IsBot()) {
+              gLogUtil.TeamInfo(Player->edict(), MAX_CLIENTS + TERRORIST + 1,
+                                "TERRORIST");
+              gLogUtil.TeamInfo(Player->edict(), MAX_CLIENTS + CT + 1, "CT");
+            }
+          }
+        }
+      }
 
-			this->m_Players[Auth].GameTime = (gpGlobals->time - this->m_Players[Auth].ConnectTime);
-		}
-	}
+      if (this->m_Players[Auth].ConnectTime <= 0.0f) {
+        this->m_Players[Auth].ConnectTime = gpGlobals->time;
+      }
+
+      this->m_Players[Auth].GameTime =
+          (gpGlobals->time - this->m_Players[Auth].ConnectTime);
+    }
+  }
 }
 
-std::map<std::string, P_PLAYER_INFO> CLogPlayer::GetPlayers()
-{
-	return this->m_Players;
+std::map<std::string, P_PLAYER_INFO> CLogPlayer::GetPlayers() {
+  return this->m_Players;
 }
 
-LP_PLAYER_INFO CLogPlayer::GetPlayer(std::string Auth)
-{
-	if (this->m_Players.find(Auth) != this->m_Players.end())
-	{
-		return &this->m_Players[Auth];
-	}
+LP_PLAYER_INFO CLogPlayer::GetPlayer(std::string Auth) {
+  if (this->m_Players.find(Auth) != this->m_Players.end()) {
+    return &this->m_Players[Auth];
+  }
 
-	return nullptr;
+  return nullptr;
 }
 
-nlohmann::ordered_json CLogPlayer::GetPlayerJson(edict_t* pEdict)
-{
-	nlohmann::ordered_json PlayerJson;
+nlohmann::ordered_json CLogPlayer::GetPlayerJson(edict_t *pEdict) {
+  nlohmann::ordered_json PlayerJson;
 
-	if (!FNullEnt(pEdict))
-	{
-		auto Auth = g_engfuncs.pfnGetPlayerAuthId(pEdict);
+  if (!FNullEnt(pEdict)) {
+    auto Auth = g_engfuncs.pfnGetPlayerAuthId(pEdict);
 
-		if (Auth)
-		{
-			auto Player = this->GetPlayer(Auth);
+    if (Auth) {
+      auto Player = this->GetPlayer(Auth);
 
-			if (Player != nullptr)
-			{
-				PlayerJson =
-				{
-					{"EntityId", Player->EntityId},
-					{"Auth", Player->Auth},
-					{"Name", Player->Name},
-					{"Address", Player->Address},
-					{"UserId", Player->UserId},
-					{"Team", Player->Team},
-					{"Frags", Player->Frags},
-					{"Deaths", Player->Deaths},
-					{"GameTime", Player->GameTime},
-					{"ConnectTime", Player->ConnectTime}
-				};
-			}
-		}
-	}
+      if (Player != nullptr) {
+        PlayerJson = {{"EntityId", Player->EntityId},
+                      {"Auth", Player->Auth},
+                      {"Name", Player->Name},
+                      {"Address", Player->Address},
+                      {"UserId", Player->UserId},
+                      {"Team", Player->Team},
+                      {"Frags", Player->Frags},
+                      {"Deaths", Player->Deaths},
+                      {"GameTime", Player->GameTime},
+                      {"ConnectTime", Player->ConnectTime}};
+      }
+    }
+  }
 
-	return PlayerJson;
+  return PlayerJson;
 }

--- a/LogApi/LogUtil.cpp
+++ b/LogApi/LogUtil.cpp
@@ -2,479 +2,416 @@
 
 CLogUtil gLogUtil;
 
-void CLogUtil::ServerExecute(std::string Command)
-{
-	if (!Command.empty())
-	{
-		if (Command.length() > 0)
-		{
-			Command += "\n";
-
-			auto String = Q_strdup(Command.c_str());
-
-			if (String)
-			{
-				if (String[0u] != '\0')
-				{
-					g_engfuncs.pfnServerCommand(String);
-				}
-			}
-		}
-	}
+void CLogUtil::ServerExecute(std::string Command) {
+  if (!Command.empty()) {
+    Command += "\n";
+    g_engfuncs.pfnServerCommand(const_cast<char *>(Command.c_str()));
+  }
 }
 
-void CLogUtil::ClientPrint(edict_t* pEntity, int msg_dest, const char* Format, ...)
-{
-	va_list argList;
+void CLogUtil::ClientPrint(edict_t *pEntity, int msg_dest, const char *Format,
+                           ...) {
+  va_list argList;
 
-	va_start(argList, Format);
+  va_start(argList, Format);
 
-	char Buffer[188] = { 0 };
+  char Buffer[188] = {0};
 
-	int Length = vsnprintf(Buffer, sizeof(Buffer), Format, argList);
+  int Length = vsnprintf(Buffer, sizeof(Buffer), Format, argList);
 
-	va_end(argList);
+  va_end(argList);
 
-	if (msg_dest == PRINT_CONSOLE)
-	{
-		if (Length > 125)
-		{
-			Length = 125;
-		}
+  if (msg_dest == PRINT_CONSOLE) {
+    if (Length > 125) {
+      Length = 125;
+    }
 
-		Buffer[Length++] = '\n';
-		Buffer[Length++] = '\n';
-		Buffer[Length] = 0;
-	}
+    Buffer[Length++] = '\n';
+    Buffer[Length++] = '\n';
+    Buffer[Length] = 0;
+  }
 
-	static int iMsgTextMsg;
+  static int iMsgTextMsg;
 
-	if (iMsgTextMsg || (iMsgTextMsg = gpMetaUtilFuncs->pfnGetUserMsgID(PLID, "TextMsg", NULL)))
-	{
-		if (pEntity && !FNullEnt(pEntity))
-		{
-			g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgTextMsg, NULL, pEntity);
-		}
-		else
-		{
-			g_engfuncs.pfnMessageBegin(MSG_BROADCAST, iMsgTextMsg, NULL, NULL);
-		}
+  if (iMsgTextMsg ||
+      (iMsgTextMsg = gpMetaUtilFuncs->pfnGetUserMsgID(PLID, "TextMsg", NULL))) {
+    if (pEntity && !FNullEnt(pEntity)) {
+      g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgTextMsg, NULL, pEntity);
+    } else {
+      g_engfuncs.pfnMessageBegin(MSG_BROADCAST, iMsgTextMsg, NULL, NULL);
+    }
 
-		g_engfuncs.pfnWriteByte(msg_dest);
-		g_engfuncs.pfnWriteString("%s");
-		g_engfuncs.pfnWriteString(Buffer);
-		g_engfuncs.pfnMessageEnd();
-	}
+    g_engfuncs.pfnWriteByte(msg_dest);
+    g_engfuncs.pfnWriteString("%s");
+    g_engfuncs.pfnWriteString(Buffer);
+    g_engfuncs.pfnMessageEnd();
+  }
 }
 
-void CLogUtil::TeamInfo(edict_t* pEntity, int playerIndex, const char* pszTeamName)
-{
-	static int iMsgTeamInfo;
+void CLogUtil::TeamInfo(edict_t *pEntity, int playerIndex,
+                        const char *pszTeamName) {
+  static int iMsgTeamInfo;
 
-	if (iMsgTeamInfo || (iMsgTeamInfo = gpMetaUtilFuncs->pfnGetUserMsgID(PLID, "TeamInfo", NULL)))
-	{
-		g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgTeamInfo, nullptr, pEntity);
-		g_engfuncs.pfnWriteByte(playerIndex);
-		g_engfuncs.pfnWriteString(pszTeamName);
-		g_engfuncs.pfnMessageEnd();
-	}
+  if (iMsgTeamInfo || (iMsgTeamInfo = gpMetaUtilFuncs->pfnGetUserMsgID(
+                           PLID, "TeamInfo", NULL))) {
+    g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgTeamInfo, nullptr, pEntity);
+    g_engfuncs.pfnWriteByte(playerIndex);
+    g_engfuncs.pfnWriteString(pszTeamName);
+    g_engfuncs.pfnMessageEnd();
+  }
 }
 
-void CLogUtil::SayText(edict_t* pEntity, int Sender, const char* Format, ...)
-{
-	static int iMsgSayText;
+void CLogUtil::SayText(edict_t *pEntity, int Sender, const char *Format, ...) {
+  static int iMsgSayText;
 
-	if (iMsgSayText || (iMsgSayText = gpMetaUtilFuncs->pfnGetUserMsgID(PLID, "SayText", NULL)))
-	{
-		char Buffer[191] = { 0 };
+  if (iMsgSayText ||
+      (iMsgSayText = gpMetaUtilFuncs->pfnGetUserMsgID(PLID, "SayText", NULL))) {
+    char Buffer[191] = {0};
 
-		va_list ArgList;
-		va_start(ArgList, Format);
-		Q_vsnprintf(Buffer, sizeof(Buffer), Format, ArgList);
-		va_end(ArgList);
+    va_list ArgList;
+    va_start(ArgList, Format);
+    Q_vsnprintf(Buffer, sizeof(Buffer), Format, ArgList);
+    va_end(ArgList);
 
-		if (Sender < PRINT_TEAM_BLUE || Sender > gpGlobals->maxClients)
-		{
-			Sender = PRINT_TEAM_DEFAULT;
-		}
-		else if (Sender < PRINT_TEAM_DEFAULT)
-		{
-			Sender = abs(Sender) + MAX_CLIENTS;
-		}
+    if (Sender < PRINT_TEAM_BLUE || Sender > gpGlobals->maxClients) {
+      Sender = PRINT_TEAM_DEFAULT;
+    } else if (Sender < PRINT_TEAM_DEFAULT) {
+      Sender = abs(Sender) + MAX_CLIENTS;
+    }
 
-		this->ParseColors(Buffer);
+    this->ParseColors(Buffer);
 
-		if (!FNullEnt(pEntity))
-		{
-			if (!(pEntity->v.flags & FL_FAKECLIENT))
-			{
-				g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgSayText, nullptr, pEntity);
-				g_engfuncs.pfnWriteByte(Sender ? Sender : ENTINDEX(pEntity));
-				g_engfuncs.pfnWriteString("%s");
-				g_engfuncs.pfnWriteString(Buffer);
-				g_engfuncs.pfnMessageEnd();
-			}
-		}
-		else
-		{
-			for (int i = 1; i <= gpGlobals->maxClients; ++i)
-			{
-				edict_t* pTempEntity = INDEXENT(i);
+    if (!FNullEnt(pEntity)) {
+      if (!(pEntity->v.flags & FL_FAKECLIENT)) {
+        g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgSayText, nullptr, pEntity);
+        g_engfuncs.pfnWriteByte(Sender ? Sender : ENTINDEX(pEntity));
+        g_engfuncs.pfnWriteString("%s");
+        g_engfuncs.pfnWriteString(Buffer);
+        g_engfuncs.pfnMessageEnd();
+      }
+    } else {
+      for (int i = 1; i <= gpGlobals->maxClients; ++i) {
+        edict_t *pTempEntity = INDEXENT(i);
 
-				if (!FNullEnt(pTempEntity))
-				{
-					if (!(pTempEntity->v.flags & FL_FAKECLIENT))
-					{
-						g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgSayText, nullptr, pTempEntity);
-						g_engfuncs.pfnWriteByte(Sender ? Sender : i);
-						g_engfuncs.pfnWriteString("%s");
-						g_engfuncs.pfnWriteString(Buffer);
-						g_engfuncs.pfnMessageEnd();
-					}
-				}
-			}
-		}
-	}
+        if (!FNullEnt(pTempEntity)) {
+          if (!(pTempEntity->v.flags & FL_FAKECLIENT)) {
+            g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgSayText, nullptr,
+                                       pTempEntity);
+            g_engfuncs.pfnWriteByte(Sender ? Sender : i);
+            g_engfuncs.pfnWriteString("%s");
+            g_engfuncs.pfnWriteString(Buffer);
+            g_engfuncs.pfnMessageEnd();
+          }
+        }
+      }
+    }
+  }
 }
 
-int CLogUtil::ParseColors(char* Buffer)
-{
-	size_t len = strlen(Buffer);
+int CLogUtil::ParseColors(char *Buffer) {
+  size_t len = strlen(Buffer);
 
-	int offs = 0;
+  int offs = 0;
 
-	if (len > 0)
-	{
-		int c;
+  if (len > 0) {
+    int c;
 
-		for (size_t i = 0; i < len; i++)
-		{
-			c = Buffer[i];
+    for (size_t i = 0; i < len; i++) {
+      c = Buffer[i];
 
-			if (c == '^' && (i != len - 1))
-			{
-				c = Buffer[++i];
+      if (c == '^' && (i != len - 1)) {
+        c = Buffer[++i];
 
-				if (c == 'n' || c == 't' || (c >= '1' && c <= '4'))
-				{
-					switch (c)
-					{
-						case '1': c = '\x01'; break;
-						case '2': c = '\x02'; break;
-						case '3': c = '\x03'; break;
-						case '4': c = '\x04'; break;
-						case 'n': c = '\n'; break;
-						case 't': c = '\t'; break;
-					}
+        if (c == 'n' || c == 't' || (c >= '1' && c <= '4')) {
+          switch (c) {
+          case '1':
+            c = '\x01';
+            break;
+          case '2':
+            c = '\x02';
+            break;
+          case '3':
+            c = '\x03';
+            break;
+          case '4':
+            c = '\x04';
+            break;
+          case 'n':
+            c = '\n';
+            break;
+          case 't':
+            c = '\t';
+            break;
+          }
 
-					offs++;
-				}
-			}
+          offs++;
+        }
+      }
 
-			Buffer[i - offs] = c;
-		}
+      Buffer[i - offs] = c;
+    }
 
-		Buffer[len - offs] = '\0';
-	}
+    Buffer[len - offs] = '\0';
+  }
 
-	return offs;
+  return offs;
 }
 
-unsigned short CLogUtil::FixedUnsigned16(float value, float scale)
-{
-	int output = value * scale;
+unsigned short CLogUtil::FixedUnsigned16(float value, float scale) {
+  int output = value * scale;
 
-	if (output < 0)
-	{
-		output = 0;
-	}
+  if (output < 0) {
+    output = 0;
+  }
 
-	if (output > USHRT_MAX)
-	{
-		output = USHRT_MAX;
-	}
+  if (output > USHRT_MAX) {
+    output = USHRT_MAX;
+  }
 
-	return (unsigned short)output;
+  return (unsigned short)output;
 }
 
-CBasePlayer* CLogUtil::FindPlayer(std::string Target)
-{
-	if (!Target.empty())
-	{
-		if (Target.length() > 1)
-		{
-			if (Target[0u] == '#')
-			{
-				if (!Target.substr(1).empty())
-				{
-					auto Find = Q_atoi(Target.substr(1).c_str());
+CBasePlayer *CLogUtil::FindPlayer(std::string Target) {
+  if (!Target.empty()) {
+    if (Target.length() > 1) {
+      if (Target[0u] == '#') {
+        if (!Target.substr(1).empty()) {
+          auto Find = Q_atoi(Target.substr(1).c_str());
 
-					if (Find > 0)
-					{
-						for (auto i = 1; i <= gpGlobals->maxClients; i++)
-						{
-							auto Player = UTIL_PlayerByIndexSafe(i);
+          if (Find > 0) {
+            for (auto i = 1; i <= gpGlobals->maxClients; i++) {
+              auto Player = UTIL_PlayerByIndexSafe(i);
 
-							if (Player)
-							{
-								if (!Player->IsDormant())
-								{
-									if (g_engfuncs.pfnGetPlayerUserId(Player->edict()) == Find)
-									{
-										return Player;
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-			else
-			{
-				std::transform(Target.begin(), Target.end(), Target.begin(), [](unsigned char character)
-				{
-					return std::tolower(character);
-				});
+              if (Player) {
+                if (!Player->IsDormant()) {
+                  if (g_engfuncs.pfnGetPlayerUserId(Player->edict()) == Find) {
+                    return Player;
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        std::transform(
+            Target.begin(), Target.end(), Target.begin(),
+            [](unsigned char character) { return std::tolower(character); });
 
-				for (auto i = 1; i <= gpGlobals->maxClients; i++)
-				{
-					auto Player = UTIL_PlayerByIndexSafe(i);
+        for (auto i = 1; i <= gpGlobals->maxClients; i++) {
+          auto Player = UTIL_PlayerByIndexSafe(i);
 
-					if (Player)
-					{
-						if (!Player->IsDormant())
-						{
-							std::string Name = STRING(Player->edict()->v.netname);
+          if (Player) {
+            if (!Player->IsDormant()) {
+              std::string Name = STRING(Player->edict()->v.netname);
 
-							if (!Name.empty())
-							{
-								std::transform(Name.begin(), Name.end(), Name.begin(), [](unsigned char character)
-								{
-									return std::tolower(character);
-								});
+              if (!Name.empty()) {
+                std::transform(Name.begin(), Name.end(), Name.begin(),
+                               [](unsigned char character) {
+                                 return std::tolower(character);
+                               });
 
-								if (Name.find(Target) != std::string::npos)
-								{
-									return Player;
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+                if (Name.find(Target) != std::string::npos) {
+                  return Player;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
-	return nullptr;
+  return nullptr;
 }
 
-short CLogUtil::FixedSigned16(float value, float scale)
-{
-	int output = value * scale;
+short CLogUtil::FixedSigned16(float value, float scale) {
+  int output = value * scale;
 
-	if (output > SHRT_MAX)
-	{
-		output = SHRT_MAX;
-	}
+  if (output > SHRT_MAX) {
+    output = SHRT_MAX;
+  }
 
-	if (output < SHRT_MIN)
-	{
-		output = SHRT_MIN;
-	}
+  if (output < SHRT_MIN) {
+    output = SHRT_MIN;
+  }
 
-	return (short)output;
+  return (short)output;
 }
 
-hudtextparms_t CLogUtil::HudParam(int red, int green, int blue, float x, float y, int effects, float fxtime, float holdtime, float fadeintime, float fadeouttime, int channel)
-{
-	hudtextparms_t hud;
+hudtextparms_t CLogUtil::HudParam(int red, int green, int blue, float x,
+                                  float y, int effects, float fxtime,
+                                  float holdtime, float fadeintime,
+                                  float fadeouttime, int channel) {
+  hudtextparms_t hud;
 
-	hud.r1 = red;
-	hud.g1 = green;
-	hud.b1 = blue;
-	hud.a1 = 255;
-	hud.r2 = 255;
-	hud.g2 = 255;
-	hud.b2 = 255;
-	hud.a2 = 255;
-	hud.x = x;
-	hud.y = y;
-	hud.effect = effects;
-	hud.fxTime = fxtime;
-	hud.holdTime = holdtime;
-	hud.fadeinTime = fadeintime;
-	hud.fadeoutTime = fadeouttime;
-	hud.channel = channel;
+  hud.r1 = red;
+  hud.g1 = green;
+  hud.b1 = blue;
+  hud.a1 = 255;
+  hud.r2 = 255;
+  hud.g2 = 255;
+  hud.b2 = 255;
+  hud.a2 = 255;
+  hud.x = x;
+  hud.y = y;
+  hud.effect = effects;
+  hud.fxTime = fxtime;
+  hud.holdTime = holdtime;
+  hud.fadeinTime = fadeintime;
+  hud.fadeoutTime = fadeouttime;
+  hud.channel = channel;
 
-	return hud;
+  return hud;
 }
 
-void CLogUtil::HudMessage(edict_t* pEntity, hudtextparms_t textparms, const char* Format, ...)
-{
-	va_list argList;
+void CLogUtil::HudMessage(edict_t *pEntity, hudtextparms_t textparms,
+                          const char *Format, ...) {
+  va_list argList;
 
-	va_start(argList, Format);
+  va_start(argList, Format);
 
-	char Buffer[511];
+  char Buffer[511];
 
-	vsnprintf(Buffer, sizeof(Buffer), Format, argList);
+  vsnprintf(Buffer, sizeof(Buffer), Format, argList);
 
-	va_end(argList);
+  va_end(argList);
 
-	if (pEntity)
-	{
-		g_engfuncs.pfnMessageBegin(MSG_ONE_UNRELIABLE, SVC_TEMPENTITY, NULL, pEntity);
-	}
-	else
-	{
-		g_engfuncs.pfnMessageBegin(MSG_BROADCAST, SVC_TEMPENTITY, NULL, NULL);
-	}
+  if (pEntity) {
+    g_engfuncs.pfnMessageBegin(MSG_ONE_UNRELIABLE, SVC_TEMPENTITY, NULL,
+                               pEntity);
+  } else {
+    g_engfuncs.pfnMessageBegin(MSG_BROADCAST, SVC_TEMPENTITY, NULL, NULL);
+  }
 
-	g_engfuncs.pfnWriteByte(TE_TEXTMESSAGE);
-	g_engfuncs.pfnWriteByte(textparms.channel & 0xFF);
+  g_engfuncs.pfnWriteByte(TE_TEXTMESSAGE);
+  g_engfuncs.pfnWriteByte(textparms.channel & 0xFF);
 
-	g_engfuncs.pfnWriteShort(this->FixedSigned16(textparms.x, BIT(13)));
-	g_engfuncs.pfnWriteShort(this->FixedSigned16(textparms.y, BIT(13)));
+  g_engfuncs.pfnWriteShort(this->FixedSigned16(textparms.x, BIT(13)));
+  g_engfuncs.pfnWriteShort(this->FixedSigned16(textparms.y, BIT(13)));
 
-	g_engfuncs.pfnWriteByte(textparms.effect);
+  g_engfuncs.pfnWriteByte(textparms.effect);
 
-	g_engfuncs.pfnWriteByte(textparms.r1);
-	g_engfuncs.pfnWriteByte(textparms.g1);
-	g_engfuncs.pfnWriteByte(textparms.b1);
-	g_engfuncs.pfnWriteByte(textparms.a1);
+  g_engfuncs.pfnWriteByte(textparms.r1);
+  g_engfuncs.pfnWriteByte(textparms.g1);
+  g_engfuncs.pfnWriteByte(textparms.b1);
+  g_engfuncs.pfnWriteByte(textparms.a1);
 
-	g_engfuncs.pfnWriteByte(textparms.r2);
-	g_engfuncs.pfnWriteByte(textparms.g2);
-	g_engfuncs.pfnWriteByte(textparms.b2);
-	g_engfuncs.pfnWriteByte(textparms.a2);
+  g_engfuncs.pfnWriteByte(textparms.r2);
+  g_engfuncs.pfnWriteByte(textparms.g2);
+  g_engfuncs.pfnWriteByte(textparms.b2);
+  g_engfuncs.pfnWriteByte(textparms.a2);
 
-	g_engfuncs.pfnWriteShort(this->FixedUnsigned16(textparms.fadeinTime, BIT(8)));
-	g_engfuncs.pfnWriteShort(this->FixedUnsigned16(textparms.fadeoutTime, BIT(8)));
-	g_engfuncs.pfnWriteShort(this->FixedUnsigned16(textparms.holdTime, BIT(8)));
+  g_engfuncs.pfnWriteShort(this->FixedUnsigned16(textparms.fadeinTime, BIT(8)));
+  g_engfuncs.pfnWriteShort(
+      this->FixedUnsigned16(textparms.fadeoutTime, BIT(8)));
+  g_engfuncs.pfnWriteShort(this->FixedUnsigned16(textparms.holdTime, BIT(8)));
 
-	if (textparms.effect == 2)
-	{
-		g_engfuncs.pfnWriteShort(this->FixedUnsigned16(textparms.fxTime, BIT(8)));
-	}
+  if (textparms.effect == 2) {
+    g_engfuncs.pfnWriteShort(this->FixedUnsigned16(textparms.fxTime, BIT(8)));
+  }
 
-	g_engfuncs.pfnWriteString(Buffer);
-	g_engfuncs.pfnMessageEnd();
+  g_engfuncs.pfnWriteString(Buffer);
+  g_engfuncs.pfnMessageEnd();
 }
 
-void CLogUtil::ShowMotd(edict_t* pEntity, char* Motd, int MotdLength)
-{
-	static int iMsgMOTD;
+void CLogUtil::ShowMotd(edict_t *pEntity, char *Motd, int MotdLength) {
+  static int iMsgMOTD;
 
-	if (iMsgMOTD || (iMsgMOTD = gpMetaUtilFuncs->pfnGetUserMsgID(PLID, "MOTD", NULL)))
-	{
-		if (MotdLength < 128)
-		{
-			struct stat FileBuffer;
+  if (iMsgMOTD ||
+      (iMsgMOTD = gpMetaUtilFuncs->pfnGetUserMsgID(PLID, "MOTD", NULL))) {
+    if (MotdLength < 128) {
+      struct stat FileBuffer;
 
-			if (stat(Motd, &FileBuffer) == 0)
-			{
-				int FileLength = 0;
+      if (stat(Motd, &FileBuffer) == 0) {
+        int FileLength = 0;
 
-				char* FileContent = reinterpret_cast<char*>(g_engfuncs.pfnLoadFileForMe(Motd, &FileLength));
+        char *FileContent = reinterpret_cast<char *>(
+            g_engfuncs.pfnLoadFileForMe(Motd, &FileLength));
 
-				if (FileLength)
-				{
-					this->ShowMotd(pEntity, FileContent, FileLength);
+        if (FileLength) {
+          this->ShowMotd(pEntity, FileContent, FileLength);
 
-					g_engfuncs.pfnFreeFile(FileContent);
+          g_engfuncs.pfnFreeFile(FileContent);
 
-					return;
-				}
-			}
-		}
+          return;
+        }
+      }
+    }
 
-		char* Buffer = Motd;
+    char *Buffer = Motd;
 
-		char Character = 0;
+    char Character = 0;
 
-		int Size = 0;
+    int Size = 0;
 
-		while (*Buffer)
-		{
-			Size = MotdLength;
+    while (*Buffer) {
+      Size = MotdLength;
 
-			if (Size > 175)
-			{
-				Size = 175;
-			}
+      if (Size > 175) {
+        Size = 175;
+      }
 
-			MotdLength -= Size;
+      MotdLength -= Size;
 
-			Character = *(Buffer += Size);
+      Character = *(Buffer += Size);
 
-			*Buffer = 0;
+      *Buffer = 0;
 
-			g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgMOTD, NULL, pEntity);
-			g_engfuncs.pfnWriteByte(Character ? FALSE : TRUE);
-			g_engfuncs.pfnWriteString(Motd);
-			g_engfuncs.pfnMessageEnd();
+      g_engfuncs.pfnMessageBegin(MSG_ONE, iMsgMOTD, NULL, pEntity);
+      g_engfuncs.pfnWriteByte(Character ? FALSE : TRUE);
+      g_engfuncs.pfnWriteString(Motd);
+      g_engfuncs.pfnMessageEnd();
 
-			*Buffer = Character;
+      *Buffer = Character;
 
-			Motd = Buffer;
-		}
-	}
+      Motd = Buffer;
+    }
+  }
 }
 
-const char* CLogUtil::GetAuthId(edict_t* pEntity)
-{
-	if (!FNullEnt(pEntity))
-	{
-		auto Auth = g_engfuncs.pfnGetPlayerAuthId(pEntity);
+const char *CLogUtil::GetAuthId(edict_t *pEntity) {
+  if (!FNullEnt(pEntity)) {
+    auto Auth = g_engfuncs.pfnGetPlayerAuthId(pEntity);
 
-		if (Auth)
-		{
-			if (Auth[0u] != '\0')
-			{
-				if (!Q_stricmp(Auth, "BOT"))
-				{
-					return STRING(pEntity->v.netname);
-				}
+    if (Auth) {
+      if (Auth[0u] != '\0') {
+        if (!Q_stricmp(Auth, "BOT")) {
+          return STRING(pEntity->v.netname);
+        }
 
-				return Auth;
-			}
-		}
-	}
+        return Auth;
+      }
+    }
+  }
 
-	return nullptr;
+  return nullptr;
 }
 
-void CLogUtil::ReplaceAll(std::string& String, const std::string& From, const std::string& To)
-{
-	if (!From.empty())
-	{
-		size_t StartPos = 0;
+void CLogUtil::ReplaceAll(std::string &String, const std::string &From,
+                          const std::string &To) {
+  if (!From.empty()) {
+    size_t StartPos = 0;
 
-		while ((StartPos = String.find(From, StartPos)) != std::string::npos)
-		{
-			String.replace(StartPos, From.length(), To);
+    while ((StartPos = String.find(From, StartPos)) != std::string::npos) {
+      String.replace(StartPos, From.length(), To);
 
-			StartPos += To.length();
-		}
-	}
+      StartPos += To.length();
+    }
+  }
 }
 
-std::vector<CBasePlayer*> CLogUtil::GetPlayers()
-{
-	std::vector<CBasePlayer*> Players;
+std::vector<CBasePlayer *> CLogUtil::GetPlayers() {
+  std::vector<CBasePlayer *> Players;
 
-	for (int i = 1; i <= gpGlobals->maxClients; ++i)
-	{
-		auto Player = UTIL_PlayerByIndexSafe(i);
+  for (int i = 1; i <= gpGlobals->maxClients; ++i) {
+    auto Player = UTIL_PlayerByIndexSafe(i);
 
-		if (Player)
-		{
-			if (Player->IsPlayer() && !Player->IsDormant())
-			{
-				Players.push_back(Player);
-			}
-		}
-	}
+    if (Player) {
+      if (Player->IsPlayer() && !Player->IsDormant()) {
+        Players.push_back(Player);
+      }
+    }
+  }
 
-	return Players;
+  return Players;
 }

--- a/LogApi/MetaMod.cpp
+++ b/LogApi/MetaMod.cpp
@@ -1,17 +1,16 @@
 #include "precompiled.h"
 
 #pragma region METAMOD
-plugin_info_t Plugin_info =
-{
-	META_INTERFACE_VERSION,
-	"Log API",
-	"0.0.2",
-	__DATE__,
-	"SmileY",
-	"https://github.com/SmileYzn/logapi",
-	"LOG",
-	PT_STARTUP,
-	PT_ANYTIME,
+plugin_info_t Plugin_info = {
+    META_INTERFACE_VERSION,
+    "Log API",
+    "0.0.2",
+    __DATE__,
+    "SmileY",
+    "https://github.com/SmileYzn/logapi",
+    "LOG",
+    PT_STARTUP,
+    PT_ANYTIME,
 };
 
 enginefuncs_t g_engfuncs;
@@ -21,267 +20,262 @@ gamedll_funcs_t *gpGamedllFuncs;
 mutil_funcs_t *gpMetaUtilFuncs;
 META_FUNCTIONS gMetaFunctionTable;
 
-C_DLLEXPORT void WINAPI GiveFnptrsToDll(enginefuncs_t *pengfuncsFromEngine, globalvars_t *pGlobals)
-{
-	memcpy(&g_engfuncs, pengfuncsFromEngine, sizeof(enginefuncs_t));
-	
-	gpGlobals = pGlobals;
+C_DLLEXPORT void WINAPI GiveFnptrsToDll(enginefuncs_t *pengfuncsFromEngine,
+                                        globalvars_t *pGlobals) {
+  memcpy(&g_engfuncs, pengfuncsFromEngine, sizeof(enginefuncs_t));
+
+  gpGlobals = pGlobals;
 }
 
-C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, meta_globals_t *pMGlobals, gamedll_funcs_t *pGamedllFuncs)
-{
-	gpMetaGlobals = pMGlobals;
+C_DLLEXPORT int Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable,
+                            meta_globals_t *pMGlobals,
+                            gamedll_funcs_t *pGamedllFuncs) {
+  gpMetaGlobals = pMGlobals;
 
-	gpGamedllFuncs = pGamedllFuncs;
+  gpGamedllFuncs = pGamedllFuncs;
 
-	memset(&gMetaFunctionTable, 0, sizeof(META_FUNCTIONS));
+  memset(&gMetaFunctionTable, 0, sizeof(META_FUNCTIONS));
 
-	gMetaFunctionTable.pfnGetEntityAPI2 = GetEntityAPI2;
+  gMetaFunctionTable.pfnGetEntityAPI2 = GetEntityAPI2;
 
-	gMetaFunctionTable.pfnGetEntityAPI2_Post = GetEntityAPI2_Post;
+  gMetaFunctionTable.pfnGetEntityAPI2_Post = GetEntityAPI2_Post;
 
-	gMetaFunctionTable.pfnGetEngineFunctions = GetEngineFunctions;
+  gMetaFunctionTable.pfnGetEngineFunctions = GetEngineFunctions;
 
-	gMetaFunctionTable.pfnGetEngineFunctions_Post = GetEngineFunctions_Post;
+  gMetaFunctionTable.pfnGetEngineFunctions_Post = GetEngineFunctions_Post;
 
-	gMetaFunctionTable.pfnGetNewDLLFunctions = GetNewDLLFunctions;
+  gMetaFunctionTable.pfnGetNewDLLFunctions = GetNewDLLFunctions;
 
-	gMetaFunctionTable.pfnGetNewDLLFunctions_Post = GetNewDLLFunctions_Post;
+  gMetaFunctionTable.pfnGetNewDLLFunctions_Post = GetNewDLLFunctions_Post;
 
-	memcpy(pFunctionTable, &gMetaFunctionTable, sizeof(META_FUNCTIONS));
+  memcpy(pFunctionTable, &gMetaFunctionTable, sizeof(META_FUNCTIONS));
 
-	ReAPI_Init();
+  ReAPI_Init();
 
-	ReGameDLL_Init();
+  ReGameDLL_Init();
 
-	return TRUE;
+  return TRUE;
 }
 
-C_DLLEXPORT int Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON reason)
-{
-	ReAPI_Stop();
+C_DLLEXPORT int Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON reason) {
+  ReAPI_Stop();
 
-	ReGameDLL_Stop();
+  ReGameDLL_Stop();
 
-	return TRUE;
+  return TRUE;
 }
 
-C_DLLEXPORT int Meta_Query(char *interfaceVersion, plugin_info_t **pPlugInfo, mutil_funcs_t *pMetaUtilFuncs)
-{
-	*pPlugInfo = PLID;
+C_DLLEXPORT int Meta_Query(char *interfaceVersion, plugin_info_t **pPlugInfo,
+                           mutil_funcs_t *pMetaUtilFuncs) {
+  *pPlugInfo = PLID;
 
-	gpMetaUtilFuncs = pMetaUtilFuncs;
+  gpMetaUtilFuncs = pMetaUtilFuncs;
 
-	return TRUE;
+  return TRUE;
 }
 #pragma endregion
 
 #pragma region META_DLL_PRE
 DLL_FUNCTIONS g_DLL_FunctionTable_Pre;
 
-C_DLLEXPORT int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
-{
-	memset(&g_DLL_FunctionTable_Pre, 0, sizeof(DLL_FUNCTIONS));
+C_DLLEXPORT int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable,
+                              int *interfaceVersion) {
+  memset(&g_DLL_FunctionTable_Pre, 0, sizeof(DLL_FUNCTIONS));
 
-	// Funtion hooks here
+  // Funtion hooks here
 
-	memcpy(pFunctionTable, &g_DLL_FunctionTable_Pre, sizeof(DLL_FUNCTIONS));
+  memcpy(pFunctionTable, &g_DLL_FunctionTable_Pre, sizeof(DLL_FUNCTIONS));
 
-	return 1;
+  return 1;
 }
 #pragma endregion
 
 #pragma region META_DLL_POST
 DLL_FUNCTIONS g_DLL_FunctionTable_Post;
 
-C_DLLEXPORT int GetEntityAPI2_Post(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
-{
-	memset(&g_DLL_FunctionTable_Post, 0, sizeof(DLL_FUNCTIONS));
+C_DLLEXPORT int GetEntityAPI2_Post(DLL_FUNCTIONS *pFunctionTable,
+                                   int *interfaceVersion) {
+  memset(&g_DLL_FunctionTable_Post, 0, sizeof(DLL_FUNCTIONS));
 
-	g_DLL_FunctionTable_Post.pfnServerActivate = DLL_POST_ServerActivate;
+  g_DLL_FunctionTable_Post.pfnServerActivate = DLL_POST_ServerActivate;
 
-	g_DLL_FunctionTable_Post.pfnServerDeactivate = DLL_POST_ServerDeactivate;
+  g_DLL_FunctionTable_Post.pfnServerDeactivate = DLL_POST_ServerDeactivate;
 
-	g_DLL_FunctionTable_Post.pfnStartFrame = DLL_POST_StartFrame;
+  g_DLL_FunctionTable_Post.pfnStartFrame = DLL_POST_StartFrame;
 
-	g_DLL_FunctionTable_Post.pfnClientConnect = DLL_POST_ClientConnect;
+  g_DLL_FunctionTable_Post.pfnClientConnect = DLL_POST_ClientConnect;
 
-	g_DLL_FunctionTable_Post.pfnClientPutInServer = DLL_POST_ClientPutInServer;
+  g_DLL_FunctionTable_Post.pfnClientPutInServer = DLL_POST_ClientPutInServer;
 
-	g_DLL_FunctionTable_Post.pfnClientKill = DLL_POST_ClientKill;
+  g_DLL_FunctionTable_Post.pfnClientKill = DLL_POST_ClientKill;
 
-	g_DLL_FunctionTable_Post.pfnClientUserInfoChanged = DLL_POST_ClientUserInfoChanged;
+  g_DLL_FunctionTable_Post.pfnClientUserInfoChanged =
+      DLL_POST_ClientUserInfoChanged;
 
-	g_DLL_FunctionTable_Post.pfnClientCommand = DLL_POST_ClientCommand;
+  g_DLL_FunctionTable_Post.pfnClientCommand = DLL_POST_ClientCommand;
 
-	memcpy(pFunctionTable, &g_DLL_FunctionTable_Post, sizeof(DLL_FUNCTIONS));
+  memcpy(pFunctionTable, &g_DLL_FunctionTable_Post, sizeof(DLL_FUNCTIONS));
 
-	return 1;
+  return 1;
 }
 
-void DLL_POST_ServerActivate(edict_t* pEdictList, int edictCount, int clientMax)
-{
-	gLogCvar.ServerActivate();
-	
-	gLogApi.ServerActivate();
+void DLL_POST_ServerActivate(edict_t *pEdictList, int edictCount,
+                             int clientMax) {
+  gLogCvar.ServerActivate();
 
-	gLogCurl.ServerActivate();
+  gLogApi.ServerActivate();
 
-	gLogCommand.ServerActivate();
+  gLogCurl.ServerActivate();
 
-	gLogEvent.ServerActivate(pEdictList, edictCount, clientMax);
+  gLogCommand.ServerActivate();
 
-	RETURN_META(MRES_IGNORED);
+  gLogEvent.ServerActivate(pEdictList, edictCount, clientMax);
+
+  RETURN_META(MRES_IGNORED);
 }
 
-void DLL_POST_ServerDeactivate(void)
-{
-	gLogApi.ServerDeactivate();
-	
-	gLogEvent.ServerDeactivate();
+void DLL_POST_ServerDeactivate(void) {
+  gLogApi.ServerDeactivate();
 
-	RETURN_META(MRES_IGNORED);
+  gLogEvent.ServerDeactivate();
+
+  RETURN_META(MRES_IGNORED);
 }
 
-void DLL_POST_StartFrame()
-{
-	gLogCurl.ServerFrame();
+void DLL_POST_StartFrame() {
+  gLogCurl.ServerFrame();
 
-	gLogApi.ServerFrame();
+  gLogApi.ServerFrame();
 
-	RETURN_META(MRES_IGNORED);
+  RETURN_META(MRES_IGNORED);
 }
 
-qboolean DLL_POST_ClientConnect(edict_t* pEntity, const char* pszName, const char* pszAddress, char szRejectReason[128])
-{
-	gLogPlayer.Connect(pEntity, pszName, pszAddress);
-	
-	gLogEvent.ClientConnect(pEntity, pszName, pszAddress, szRejectReason);
+qboolean DLL_POST_ClientConnect(edict_t *pEntity, const char *pszName,
+                                const char *pszAddress,
+                                char szRejectReason[128]) {
+  gLogPlayer.Connect(pEntity, pszName, pszAddress);
 
-	RETURN_META_VALUE(MRES_IGNORED, TRUE);
+  gLogEvent.ClientConnect(pEntity, pszName, pszAddress, szRejectReason);
+
+  RETURN_META_VALUE(MRES_IGNORED, TRUE);
 }
 
-void DLL_POST_ClientPutInServer(edict_t* pEntity)
-{
-	gLogPlayer.Update(pEntity);
+void DLL_POST_ClientPutInServer(edict_t *pEntity) {
+  gLogPlayer.Update(pEntity);
 
-	gLogEvent.ClientPutInServer(pEntity);
+  gLogEvent.ClientPutInServer(pEntity);
 
-	RETURN_META(MRES_IGNORED);
+  RETURN_META(MRES_IGNORED);
 }
 
-void DLL_POST_ClientKill(edict_t* pEntity)
-{
-	gLogPlayer.Update(pEntity);
+void DLL_POST_ClientKill(edict_t *pEntity) {
+  gLogPlayer.Update(pEntity);
 
-	gLogEvent.ClientKill(pEntity);
+  gLogEvent.ClientKill(pEntity);
 
-	RETURN_META(MRES_IGNORED);
+  RETURN_META(MRES_IGNORED);
 }
 
-void DLL_POST_ClientUserInfoChanged(edict_t* pEntity, char* InfoBuffer)
-{
-	gLogPlayer.Update(pEntity);
+void DLL_POST_ClientUserInfoChanged(edict_t *pEntity, char *InfoBuffer) {
+  gLogPlayer.Update(pEntity);
 
-	gLogEvent.ClientUserInfoChanged(pEntity, InfoBuffer);
+  gLogEvent.ClientUserInfoChanged(pEntity, InfoBuffer);
 
-	RETURN_META(MRES_IGNORED);
+  RETURN_META(MRES_IGNORED);
 }
 
-void DLL_POST_ClientCommand(edict_t* pEntity)
-{
-	if (pEntity)
-	{
-		if (!FNullEnt(pEntity))
-		{
-			gLogPlayer.Update(pEntity);
+void DLL_POST_ClientCommand(edict_t *pEntity) {
+  if (pEntity) {
+    if (!FNullEnt(pEntity)) {
+      gLogPlayer.Update(pEntity);
 
-			gLogEvent.ClientCommand(pEntity);
+      gLogEvent.ClientCommand(pEntity);
 
-			gLogEvent.ClientSay(pEntity);
-		}
-	}
+      gLogEvent.ClientSay(pEntity);
+    }
+  }
 
-	RETURN_META(MRES_IGNORED);
+  RETURN_META(MRES_IGNORED);
 }
 #pragma endregion
 
 #pragma region NEW_DLL_PRE
 NEW_DLL_FUNCTIONS g_DLL_NewFunctionTable_Pre;
 
-C_DLLEXPORT int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion)
-{
-	memset(&g_DLL_NewFunctionTable_Pre, 0, sizeof(NEW_DLL_FUNCTIONS));
+C_DLLEXPORT int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunctionTable,
+                                   int *interfaceVersion) {
+  memset(&g_DLL_NewFunctionTable_Pre, 0, sizeof(NEW_DLL_FUNCTIONS));
 
-	// Funtion hooks here
+  // Funtion hooks here
 
-	memcpy(pNewFunctionTable, &g_DLL_NewFunctionTable_Pre, sizeof(NEW_DLL_FUNCTIONS));
+  memcpy(pNewFunctionTable, &g_DLL_NewFunctionTable_Pre,
+         sizeof(NEW_DLL_FUNCTIONS));
 
-	return 1;
+  return 1;
 }
 #pragma endregion
 
 #pragma region NEW_DLL_POST
 NEW_DLL_FUNCTIONS g_DLL_NewFunctionTable_Post;
 
-C_DLLEXPORT int GetNewDLLFunctions_Post(NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion)
-{
-	memset(&g_DLL_NewFunctionTable_Post, 0, sizeof(NEW_DLL_FUNCTIONS));
+C_DLLEXPORT int GetNewDLLFunctions_Post(NEW_DLL_FUNCTIONS *pNewFunctionTable,
+                                        int *interfaceVersion) {
+  memset(&g_DLL_NewFunctionTable_Post, 0, sizeof(NEW_DLL_FUNCTIONS));
 
-	// Funtion hooks here
+  // Funtion hooks here
 
-	memcpy(pNewFunctionTable, &g_DLL_NewFunctionTable_Post, sizeof(NEW_DLL_FUNCTIONS));
+  memcpy(pNewFunctionTable, &g_DLL_NewFunctionTable_Post,
+         sizeof(NEW_DLL_FUNCTIONS));
 
-	return 1;
+  return 1;
 }
 #pragma endregion
 
 #pragma region ENGINE_PRE
 enginefuncs_t g_ENGINE_FunctionTable_Pre;
 
-C_DLLEXPORT int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
-{
-	memset(&g_ENGINE_FunctionTable_Pre, 0, sizeof(enginefuncs_t));
+C_DLLEXPORT int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine,
+                                   int *interfaceVersion) {
+  memset(&g_ENGINE_FunctionTable_Pre, 0, sizeof(enginefuncs_t));
 
-	// Funtion hooks here
+  // Funtion hooks here
 
-	memcpy(pengfuncsFromEngine, &g_ENGINE_FunctionTable_Pre, sizeof(enginefuncs_t));
+  memcpy(pengfuncsFromEngine, &g_ENGINE_FunctionTable_Pre,
+         sizeof(enginefuncs_t));
 
-	return 1;
+  return 1;
 }
 #pragma endregion
 
 #pragma region ENGINE_POST
 enginefuncs_t g_ENGINE_FunctionTable_Post;
 
-C_DLLEXPORT int GetEngineFunctions_Post(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
-{
-	memset(&g_ENGINE_FunctionTable_Post, 0, sizeof(enginefuncs_t));
+C_DLLEXPORT int GetEngineFunctions_Post(enginefuncs_t *pengfuncsFromEngine,
+                                        int *interfaceVersion) {
+  memset(&g_ENGINE_FunctionTable_Post, 0, sizeof(enginefuncs_t));
 
-	g_ENGINE_FunctionTable_Post.pfnAlertMessage = ENGINE_POST_AlertMessage;
+  g_ENGINE_FunctionTable_Post.pfnAlertMessage = ENGINE_POST_AlertMessage;
 
-	memcpy(pengfuncsFromEngine, &g_ENGINE_FunctionTable_Post, sizeof(enginefuncs_t));
+  memcpy(pengfuncsFromEngine, &g_ENGINE_FunctionTable_Post,
+         sizeof(enginefuncs_t));
 
-	return 1;
+  return 1;
 }
 
-void ENGINE_POST_AlertMessage(ALERT_TYPE atype, const char* szFmt, ...)
-{
-	if (atype == at_logged)
-	{
-		static char szBuffer[1024];
+void ENGINE_POST_AlertMessage(ALERT_TYPE atype, const char *szFmt, ...) {
+  if (atype == at_logged) {
+    static char szBuffer[1024];
 
-		va_list vArgList;
-		va_start(vArgList, szFmt);
-		vsprintf(szBuffer, szFmt, vArgList);
-		va_end(vArgList);
+    va_list vArgList;
+    va_start(vArgList, szFmt);
+    vsnprintf(szBuffer, sizeof(szBuffer), szFmt, vArgList);
+    va_end(vArgList);
 
-		if (szBuffer[0u] != '\0')
-		{
-			gLogEvent.ServerAlertMessage(atype, szBuffer);
-		}
-	}
+    if (szBuffer[0u] != '\0') {
+      gLogEvent.ServerAlertMessage(atype, szBuffer);
+    }
+  }
 
-	RETURN_META(MRES_IGNORED);
+  RETURN_META(MRES_IGNORED);
 }
 #pragma endregion

--- a/README.md
+++ b/README.md
@@ -169,14 +169,14 @@ class LogAPI
     /**
      * On Client Put In Server
      * 
-     * @param string $Event             Event Name
-     * @param array $Server		Server information data
-     * @param array $Player		Player information data
+     * @param array $request            Full request data with keys: Event, Server, Player
      * 
      * @return mixed                    Array containing LogAPI commands or null
      */
-    protected function ClientPutInServer($Event, $Server, $Player)
+    protected function ClientPutInServer($request)
     {
+        $Player = $request['Player'];
+
         // Print Chat
         $result["PrintChat"] =
         [

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ log_api_bearer "YOUR_API_TOKEN_CVAR"
 //
 // Default "60.0"
 log_api_delay "60.0"
+
+// Execute Commands
+// Allows the webserver to execute commands on the CS server via the `ServerCommand` or `ServerExecute` JSON response
+// Warning: Only enable if your webserver communication is strictly secure!
+//
+// 0 Disable execution of commands from webserver
+// 1 Enable execution of commands from webserver
+//
+// Default "0"
+log_api_exec_commands "0"
 ```
 
 3. Let's create the api.php file (log_api_addres must be something like: https://yourwebsite.com/api.php)

--- a/cstrike/addons/logapi/LogApi.php
+++ b/cstrike/addons/logapi/LogApi.php
@@ -10,27 +10,41 @@ class LogAPI
     private $logApiToken = "YOUR_API_TOKEN_CVAR";
 
     /**
+     * The allowed events whitelist
+     * 
+     * @var array
+     */
+    private $allowedEvents = [
+        'ServerActivate',
+        'ServerDeactivate',
+        'ServerAlertMessage',
+        'ServerInfo',
+        'ClientConnect',
+        'ClientPutInServer',
+        'ClientDisconnect',
+        'ClientKill',
+        'ClientUserInfoChanged',
+        'ClientCommand',
+        'ClientSay',
+        'ClientMenuHandle'
+    ];
+
+    /**
      * On Receive Event
      */
     public function OnEvent()
     {
-        // Compare HTTP_AUTHORIZATION with Bearer Token of log_api_bearer
-        if (trim(str_replace('Bearer', '', $_SERVER['HTTP_AUTHORIZATION'])) == $this->logApiToken)
-        {
+        // Compare HTTP_AUTHORIZATION with Bearer Token of log_api_bearer using constant-time comparison
+        if (hash_equals($this->logApiToken, trim(str_replace('Bearer', '', $_SERVER['HTTP_AUTHORIZATION'] ?? '')))) {
             // Parse request as json event
             $request = json_decode(file_get_contents('php://input'), true);
-            
-            // If event is not empty
-            if (!empty($request['Event']))
-            {
-                // If method exists
-                if (method_exists($this, $request['Event']))
-                {
-                    // Process paramemeters as array
-                    $parameters = array_values($request);
 
-                    // Return from function call
-                    $result = $this->{$request['Event']}(...$parameters);
+            // If event is not empty
+            if (!empty($request['Event'])) {
+                // If event is allowed in whitelist and method exists
+                if (in_array($request['Event'], $this->allowedEvents, true) && method_exists($this, $request['Event'])) {
+                    // Return from function call (pass request array directly)
+                    $result = $this->{$request['Event']}($request);
 
                     // Set PHP to return content type as json
                     header('Content-Type: application/json');
@@ -39,9 +53,7 @@ class LogAPI
                     die(json_encode($result));
                 }
             }
-        }
-        else
-        {
+        } else {
             header("HTTP/1.1 401 Unauthorized");
         }
     }
@@ -50,42 +62,35 @@ class LogAPI
      * On Server Activate Event
      * 
      * 
-     * @param string $Event         Event Name
-     * @param array $Server		    Server information data
-     * @param string $EdictCount    Entity Count in Server (Number of edict)
-     * @param string $ClientMax     Number of maximum allowed clients in server
+     * @param array $request    Full request data with keys: Event, Server, EdictCount, ClientMax
      * 
      * @return mixed                Array containing LogAPI commands to server or null
      */
-    protected function ServerActivate($Event, $Server, $EdictCount, $ClientMax)
+    protected function ServerActivate($request)
     {
         return null;
     }
-    
+
     /**
      * On Server Deactivate Event
      * 
-     * @param string $Event     Event Name
-     * @param array $Server     Server information data
+     * @param array $request    Full request data with keys: Event, Server
      * 
      * @return mixed            Array containing LogAPI commands to server or null
      */
-    protected function ServerDeactivate($Event, $Server)
+    protected function ServerDeactivate($request)
     {
         return null;
     }
-    
+
     /**
      * On Server Alert Message
      * 
-     * @param string $Event     Event Name
-     * @param array $Server		Server information data
-     * @param string $Type      Alert Mesasge Type (Always 5 at_logged)
-     * @param string $Message   Log string
+     * @param array $request    Full request data with keys: Event, Server, Type, Message
      * 
      * @return mixed            Array containing LogAPI commands to server or null
      */
-    protected function ServerAlertMessage($Event, $Server, $Type, $Message)
+    protected function ServerAlertMessage($request)
     {
         return null;
     }
@@ -93,115 +98,95 @@ class LogAPI
     /**
      * On Server Update Information
      * 
-     * @param string $Event     Event Name
-     * @param array $Server		Server information data
+     * @param array $request    Full request data with keys: Event, Server
      *
      * @return mixed            Array containing LogAPI commands to server or null
      */
-    protected function ServerInfo($Event, $Server)
+    protected function ServerInfo($request)
     {
         return null;
     }
-    
+
     /**
      * On Client Connect
      * 
-     * @param string $Event     Event Name
-     * @param array $Server		Server information data
-     * @param array $Player		Player information data
+     * @param array $request    Full request data with keys: Event, Server, Player
      * 
      * @return mixed            Array containing LogAPI commands to server or null
      */
-    protected function ClientConnect($Event, $Server, $Player)
+    protected function ClientConnect($request)
     {
         return null;
     }
-    
+
     /**
      * On Client Put In Server
      * 
-     * @param string $Event     Event Name
-     * @param array $Server		Server information data
-     * @param array $Player		Player information data
+     * @param array $request    Full request data with keys: Event, Server, Player
      * 
      * @return mixed            Array containing LogAPI commands or null
      */
-    protected function ClientPutInServer($Event, $Server, $Player)
+    protected function ClientPutInServer($request)
     {
         return null;
     }
-    
+
     /**
      * On Client Disconnect
      * 
-     * @param string $Event     Event Name
-     * @param array $Server		Server information data
-     * @param array $Player		Player information data
+     * @param array $request    Full request data with keys: Event, Server, Player, Crash, Reason
      * 
      * @return mixed            Array containing LogAPI commands to server or null
      */
-    protected function ClientDisconnect($Event, $Server, $Player)
+    protected function ClientDisconnect($request)
     {
         return null;
     }
-    
+
     /**
      * On Client Killed
      * 
-     * @param string $Event     Event Name
-     * @param array $Server		Server information data
-     * @param array $Player		Player information data
+     * @param array $request    Full request data with keys: Event, Server, Player
      * 
      * @return mixed            Array containing LogAPI commands or null
      */
-    protected function ClientKill($Event, $Server, $Player)
+    protected function ClientKill($request)
     {
         return null;
     }
-    
+
     /**
      * On Client Information Changed
      * 
-     * @param string $Event         Event Name
-     * @param array $Server		    Server information data
-     * @param array $Player		    Player information data
-     * @param string $InfoBuffer    KeyInfoBuffer
+     * @param array $request    Full request data with keys: Event, Server, Player, InfoBuffer
      * 
      * @return mixed                Array containing LogAPI commands to server or null
      */
-    protected function ClientUserInfoChanged($Event, $Server, $Player, $InfoBuffer)
+    protected function ClientUserInfoChanged($request)
     {
         return null;
     }
-    
+
     /**
      * On Client Command
      * 
-     * @param string $Event     Event Name
-     * @param array $Server		Server information data
-     * @param array $Player		Player information data
-     * @param string $Command   Command
-     * @param string $Args      Command Arguments
+     * @param array $request    Full request data with keys: Event, Server, Player, Command, Args
      * 
      * @return mixed            Array containing LogAPI commands to server or null
      */
-    protected function ClientCommand($Event, $Server, $Player, $Command, $Args)
+    protected function ClientCommand($request)
     {
         return null;
     }
-    
+
     /**
      * On Client say or say_team commands
      * 
-     * @param string $Event     Event Name
-     * @param array $Server		Server information data
-     * @param array $Player		Player information data
-     * @param string $Type      Type (say or say_team)
-     * @param string $Message   Message sent
+     * @param array $request    Full request data with keys: Event, Server, Player, Type, Message
      * 
      * @return mixed             Array containing LogAPI commands to server or null
      */
-    protected function ClientSay($Event, $Server, $Player, $Type, $Message)
+    protected function ClientSay($request)
     {
         return null;
     }
@@ -209,17 +194,11 @@ class LogAPI
     /**
      * On Client menu handle command
      * 
-     * @param string $Event     Event Name (Menu callback name)
-     * @param array $Server     Server information data
-     * @param array $Player     Player information data
-     * @param string $Info      Info string passed to menu item option
-     * @param string $Text      Text of option string passed to menu item
-     * @param boolean $Disabled This option is disabled or not
-     * @param string $Extra     Extra information string passed to menu item option
+     * @param array $request    Full request data with keys: Event, Server, Player, Item (Info, Text, Disabled, Extra)
      *
      * @return mixed            Array containing LogAPI commands to server or null
      */
-    protected function ClientMenuHandle($Event, $Server, $Player, $Info, $Text, $Disabled, $Extra)
+    protected function ClientMenuHandle($request)
     {
         return null;
     }

--- a/cstrike/addons/logapi/logapi.cfg
+++ b/cstrike/addons/logapi/logapi.cfg
@@ -29,3 +29,13 @@ log_api_bearer ""
 //
 // Default "60.0"
 log_api_delay "60.0"
+
+// Execute Commands
+// Allows the webserver to execute commands on the CS server via the `ServerCommand` or `ServerExecute` JSON response
+// Warning: Only enable if your webserver communication is strictly secure!
+//
+// 0 Disable execution of commands from webserver
+// 1 Enable execution of commands from webserver
+//
+// Default "0"
+log_api_exec_commands "0"


### PR DESCRIPTION
Hello! I recently conducted a deep technical security audit on the LogAPI plugin and found some critical vulnerabilities and stability issues that could affect server performance or allow exploits (like RCE/Method Injection).

I have implemented and tested all the fixes in this Pull Request.

### 🛡️ C++ Fixes & Stability
- **Buffer Overflow:** Fixed an unbounded `vsprintf` in `ENGINE_POST_AlertMessage` by switching to `vsnprintf`.
- **Double-Free / UB:** Removed a duplicate `curl_easy_cleanup` call in `CallbackResult` that was causing undefined behavior since `CLogCurl` already cleans up the handle.
- **Memory Leak:** Fixed a memory leak in `CLogCurl` where the `curl_slist` (HTTP headers) was never freed after the request finished.
- **Engine Spikes:** Added a limit to `curl_multi_info_read` (max 5 per frame) to prevent severe engine frame drops when the HTTP server responds to many events simultaneously.
- **Variable Overflow:** Added protection against long overflow for `m_RequestIndex`.
- **Missing CVAR:** Fixed compilation error `C2039` by properly declaring `m_ExecCommands` in `LogCvar.h`.

### 🔒 PHP Fixes & Security
- **Method Injection (RCE) Prevention:** Replaced the arbitrary `method_exists` call with a strict `$allowedEvents` whitelist. Previously, an attacker could manipulate the JSON "Event" key to call protected PHP magic methods like `__construct`.
- **Timing Attack Prevention:** Replaced the standard `==` token comparison with `hash_equals()` to prevent cryptographic timing attacks on the Bearer token.
- **Parameter Reordering Attack:** Changed the event handler signatures. Instead of using `array_values($request)` (which is vulnerable to JSON key reordering), the HTTP handlers now directly receive the single `$request` array.

### 📝 Documentation Updates
- Added the missing `log_api_exec_commands` Cvar to `cstrike/addons/logapi/logapi.cfg` and `README.md`.
- Updated the PHP example in `README.md` to reflect the breaking change in the event handler signatures (using `$request` array).

**Note:** The PHP change is a breaking change for existing custom handlers, but it is strictly necessary to prevent parameter injection.
