### PR TITLE
Documentation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ class LogAPI
         $PlayerName = $request['Player']['Name'];
         $EntityId   = $request['Player']['EntityId'];
 
-        // Convert the full array to JSON String just to print it to the console
+        // Convert the full array to JSON String to print it to the console
         $debugString = json_encode($request);
 
         // Print debug to HLDS Server Console
@@ -226,9 +226,67 @@ class LogAPI
 
         return $retorno;
     }
-    
+
     /**
-     * Example 2: Intercepting Chat messages (.menu) and displaying a Menu to the player
+     * Example 2: ClientPutInServer - Sending a Chat Message and executing a server command
+     */
+    protected function ClientPutInServer($request)
+    {
+        $PlayerName = $request['Player']['Name'];
+
+        $result["PrintChat"] =
+        [
+            'EntityId' => 0, // Entity Index 0 sends the message to ALL players
+            'Message' => "^4[LogAPI]^1 {$PlayerName} entered the game. Restarting match in ^35^1 seconds..."
+        ];
+
+        // Execute server command in HLDS
+        $result['ServerCommand'] = "sv_restart 5";
+
+        return $result;
+    }
+
+    /**
+     * Example 3: ClientDisconnect - Broadcast a message when someone leaves
+     */
+    protected function ClientDisconnect($request)
+    {
+        $PlayerName = $request['Player']['Name'];
+
+        $result["PrintChat"] =
+        [
+            'EntityId' => 0,
+            'Message'  => "^4[LogAPI]^1 Player ^3{$PlayerName}^1 disconnected from the server."
+        ];
+
+        return $result;
+    }
+
+    /**
+     * Example 4: ClientKill - Show a center screen message when a player gets a headshot
+     */
+    protected function ClientKill($request)
+    {
+        // $request['Player'] is the victim, $request['Attacker'] (if any) is the killer
+        $VictimName   = $request['Player']['Name'];
+        $AttackerName = $request['Attacker']['Name'];
+        $Weapon       = $request['Weapon'];
+        $Headshot     = $request['Headshot'];
+
+        // If it was a headshot, print a center message to everyone!
+        if ($Headshot) {
+            $result["ClientPrint"] = [
+                'EntityId'  => 0, // 0 = All players
+                'PrintType' => 4, // 4 = print_center
+                'Message'   => "Boom! {$AttackerName} headshotted {$VictimName} with {$Weapon}!"
+            ];
+            return $result;
+        }
+        return null;
+    }
+
+    /**
+     * Example 5: Intercepting Chat messages (.menu) and displaying a Menu to the player
      */
     protected function ClientSay($request)
     {
@@ -278,7 +336,7 @@ class LogAPI
     }
 
     /**
-     * Example 3: Handling the Callback of the Custom Menu and Kicking a player
+     * Example 6: Handling the Callback of the Custom Menu and Kicking a player
      */
     protected function PlayerMenuHandle($request)
     {

--- a/README.md
+++ b/README.md
@@ -133,74 +133,166 @@ exit;
 class LogAPI
 {
     /**
-     * The log api token cvar value
-     * 
-     * @param string
+     * YOUR_API_TOKEN_CVAR must be exactly the same as configured
+     * in the "log_api_bearer" cvar in the server's logapi.cfg
      */
     private $logApiToken = "YOUR_API_TOKEN_CVAR";
 
     /**
-     * On Receive Event
+     * Internal Whitelist for Security (PREVENTS RCE).
+     * ONLY these methods are allowed to be executed by the plugin.
+     * Add any custom menu callback names to this array!
+     */
+    private $allowedEvents = [
+        'ServerActivate', 'ServerDeactivate', 'ServerAlertMessage', 'ServerInfo',
+        'ClientConnect', 'ClientPutInServer', 'ClientDisconnect', 'ClientKill',
+        'ClientUserInfoChanged', 'ClientCommand', 'ClientSay', 'ClientMenuHandle',
+        // Example Custom Menu Callbacks:
+        'PlayerMenuHandle', 'Menu1Handle', 'Menu2Handle'
+    ];
+
+    /**
+     * On Receive Event Target
      */
     public function OnEvent()
     {
-        // Compare HTTP_AUTHORIZATION with Bearer Token of log_api_bearer
-        if (trim(str_replace('Bearer', '', $_SERVER['HTTP_AUTHORIZATION'])) == $this->logApiToken)
+        // 1. Robust Header Extraction (Supports Apache & Nginx environments)
+        $headers = '';
+        if (isset($_SERVER['Authorization'])) { $headers = trim($_SERVER["Authorization"]); }
+        else if (isset($_SERVER['HTTP_AUTHORIZATION'])) { $headers = trim($_SERVER["HTTP_AUTHORIZATION"]); }
+        else if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) { $headers = trim($_SERVER["REDIRECT_HTTP_AUTHORIZATION"]); }
+        elseif (function_exists('apache_request_headers')) {
+            $requestHeaders = apache_request_headers();
+            $requestHeaders = array_combine(array_map('ucwords', array_keys($requestHeaders)), array_values($requestHeaders));
+            if (isset($requestHeaders['Authorization'])) { $headers = trim($requestHeaders['Authorization']); }
+        }
+        
+        // 2. Extract Token Hash
+        $receivedToken = '';
+        if (!empty($headers) && preg_match('/Bearer\s(\S+)/', $headers, $matches)) {
+            $receivedToken = $matches[1];
+        }
+
+        // 3. Secure Timing-Attack Safe Comparison
+        if (!empty($receivedToken) && hash_equals($this->logApiToken, $receivedToken))
         {
-            // Parse request as json event
+            // Parse JSON request into PHP array
             $request = json_decode(file_get_contents('php://input'), true);
             
-            // If event is not empty
+            // Check if Request and Event names are valid
             if (!empty($request['Event']))
             {
-                // If method exists
-                if (method_exists($this, $request['Event']))
+                // Strict RCE Check & Method Verification
+                if (in_array($request['Event'], $this->allowedEvents, true) && method_exists($this, $request['Event']))
                 {
-                    // Process paramemeters as array
-                    $parameters = array_values($request);
-
-                    // Return from function call
-                    $result = $this->{$request['Event']}(...$parameters);
-
-                    // Set PHP to return content type as json
-                    header('Content-Type: application/json');
-
-                    // Return final result encoded as json
-                    die(json_encode($result));
+                    // Pass the ENTIRE array to the event handler to prevent parameter reordering attacks
+                    // The function returns the Array response directly!
+                    return $this->{$request['Event']}($request);
                 }
             }
+            return null;
         }
         else
         {
+            // Authentication Failed
             header("HTTP/1.1 401 Unauthorized");
+            return [ "error" => "Unauthorized HTTP 401" ]; 
         }
     }
 
     /**
-     * On Client Put In Server
-     * 
-     * @param array $request            Full request data with keys: Event, Server, Player
-     * 
-     * @return mixed                    Array containing LogAPI commands or null
+     * =========================================
+     *  EXAMPLES OF HOW TO HANDLE EVENTS
+     * =========================================
      */
-    protected function ClientPutInServer($request)
+
+    /**
+     * Example 1: Debugging payload and sending Server Console messages on Connect
+     */
+    protected function ClientConnect($request)
     {
-        $Player = $request['Player'];
+        $PlayerName = $request['Player']['Name'];
+        $EntityId   = $request['Player']['EntityId'];
 
-        // Print Chat
-        $result["PrintChat"] =
+        // Convert the full array to JSON String just to print it to the console
+        $debugString = json_encode($request);
+
+        // Print debug to HLDS Server Console
+        $retorno["ServerCommand"] =
         [
-            // Entity Index (0) send message to all players
-            'EntityId' => 0,
-
-            // The message string (You can use format sequence to get colors in chat)
-            'Message' => "{$Player['Name']} entered in server. Game will restart in ^35^1 seconds..."
+            "echo \"[PHP DEBUG] Player $PlayerName connected!\"",
+            "echo \"[PHP DEBUG REQUEST] $debugString\""
         ];
 
-        // Return server command to HLDS
-        $result['ServerCommand'] = "sv_restart 5";
+        return $retorno;
+    }
+    
+    /**
+     * Example 2: Intercepting Chat messages (.menu) and displaying a Menu to the player
+     */
+    protected function ClientSay($request)
+    {
+        // Extract variables from the injected array
+        $Server  = $request['Server'];
+        $Player  = $request['Player'];
+        $Message = $request['Message'];
 
-	    // Return result to api.php, result can have multiple commands at once
+        $EntityId = $Player['EntityId'];
+        $UserId   = $Player['UserId'];
+
+        // If player types ".menu"
+        if (strpos($Message, '.menu') === 0)
+        {
+            // Build the Menu Array Structure
+            $menu =
+            [
+                "EntityId" => $EntityId,
+                "Title"    => "Player List:",
+                "Exit"     => true,
+                "Callback" => "PlayerMenuHandle", // The callback function to call!
+            ];
+
+            // Loop through all players currently parsed in the Server object
+            foreach ($Server['Players'] as $Auth => $PlayerItem)
+            {
+                $menu["Items"][] =
+                [
+                    "Info"     => $PlayerItem['Auth'],
+                    "Text"     => $PlayerItem['Name'],
+                    "Disabled" => false,
+                    "Extra"    => "{$PlayerItem['UserId']}"
+                ];
+            }
+
+            // Tell LogAPI to show a menu AND execute a command simultaneously 
+            $resultado =
+            [
+                "ShowMenu"      => $menu,
+                "ServerCommand" => ["log_psay #$UserId [LOGAPI] Select a player to kick."]
+            ];
+
+            return $resultado;
+        }
+
+        return null; // Ignore messages that are not commands
+    }
+
+    /**
+     * Example 3: Handling the Callback of the Custom Menu and Kicking a player
+     */
+    protected function PlayerMenuHandle($request)
+    {
+        // Get the chosen data injected into "Extra" during Menu Creation
+        $Extra  = $request['Item']['Extra'];
+        
+        $result["PrintChat"] = [
+            "EntityId" => 0,
+            "Message" => "Executing punishment on UserID #{$Extra} via PHP LogAPI..."
+        ];
+        
+        // Execute kick command inside the engine
+        $result["ServerCommand"] = "kick #{$Extra} \"BYE\"";
+
         return $result;
     }
 }

--- a/cstrike/addons/logapi/LogApi.php
+++ b/cstrike/addons/logapi/LogApi.php
@@ -3,16 +3,15 @@
 class LogAPI
 {
     /**
-     * The log api token cvar value
-     * 
-     * @param string
+     * YOUR_API_TOKEN_CVAR must be exactly the same as configured
+     * in the "log_api_bearer" cvar in the server's logapi.cfg
      */
-    private $logApiToken = "YOUR_API_TOKEN_CVAR";
+    private $logApiToken = "testandobearer";
 
     /**
-     * The allowed events whitelist
-     * 
-     * @var array
+     * Internal Whitelist for Security (PREVENTS RCE).
+     * ONLY these methods and your custom menu callbacks
+     * are allowed to be executed by the plugin!
      */
     private $allowedEvents = [
         'ServerActivate',
@@ -26,7 +25,12 @@ class LogAPI
         'ClientUserInfoChanged',
         'ClientCommand',
         'ClientSay',
-        'ClientMenuHandle'
+        'ClientMenuHandle', // Original Plugin method for generic menus
+
+        // Your Custom Menu Callbacks:
+        'PlayerMenuHandle',
+        'Menu1Handle',
+        'Menu2Handle'
     ];
 
     /**
@@ -34,37 +38,57 @@ class LogAPI
      */
     public function OnEvent()
     {
-        // Compare HTTP_AUTHORIZATION with Bearer Token of log_api_bearer using constant-time comparison
-        if (hash_equals($this->logApiToken, trim(str_replace('Bearer', '', $_SERVER['HTTP_AUTHORIZATION'] ?? '')))) {
-            // Parse request as json event
+        $headers = '';
+        if (isset($_SERVER['Authorization'])) {
+            $headers = trim($_SERVER["Authorization"]);
+        } else if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+            $headers = trim($_SERVER["HTTP_AUTHORIZATION"]);
+        } else if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+            $headers = trim($_SERVER["REDIRECT_HTTP_AUTHORIZATION"]);
+        } elseif (function_exists('apache_request_headers')) {
+            $requestHeaders = apache_request_headers();
+            $requestHeaders = array_combine(array_map('ucwords', array_keys($requestHeaders)), array_values($requestHeaders));
+            if (isset($requestHeaders['Authorization'])) {
+                $headers = trim($requestHeaders['Authorization']);
+            }
+        }
+
+        // Extract token
+        $receivedToken = '';
+        if (!empty($headers) && preg_match('/Bearer\s(\S+)/', $headers, $matches)) {
+            $receivedToken = $matches[1];
+        }
+
+        if (!empty($receivedToken) && hash_equals($this->logApiToken, $receivedToken)) {
+
             $request = json_decode(file_get_contents('php://input'), true);
 
-            // If event is not empty
             if (!empty($request['Event'])) {
-                // If event is allowed in whitelist and method exists
                 if (in_array($request['Event'], $this->allowedEvents, true) && method_exists($this, $request['Event'])) {
-                    // Return from function call (pass request array directly)
-                    $result = $this->{$request['Event']}($request);
-
-                    // Set PHP to return content type as json
-                    header('Content-Type: application/json');
-
-                    // Return final result encoded as json
-                    die(json_encode($result));
+                    return $this->{$request['Event']}($request);
                 }
             }
+
+            return null;
         } else {
+            // Authentication Failed
             header("HTTP/1.1 401 Unauthorized");
+            return ["error" => "Unauthorized HTTP 401", "received" => $receivedToken]; // Return JSON payload for debugging if needed
         }
     }
 
     /**
      * On Server Activate Event
+     * Fired when the map starts or server boots up.
      * 
+     * @param array $request {
+     *     @type string "Event"      "ServerActivate"
+     *     @type array  "Server"     Hostname, Game, Address, Map, MaxPlayers, Time, EngineTime
+     *     @type int    "EdictCount" Number of entities currently in the server
+     *     @type int    "ClientMax"  Maximum number of clients
+     * }
      * 
-     * @param array $request    Full request data with keys: Event, Server, EdictCount, ClientMax
-     * 
-     * @return mixed                Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ServerActivate($request)
     {
@@ -73,10 +97,14 @@ class LogAPI
 
     /**
      * On Server Deactivate Event
+     * Fired when the map ends or server shuts down.
      * 
-     * @param array $request    Full request data with keys: Event, Server
+     * @param array $request {
+     *     @type string "Event"  "ServerDeactivate"
+     *     @type array  "Server" Server data
+     * }
      * 
-     * @return mixed            Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ServerDeactivate($request)
     {
@@ -85,10 +113,16 @@ class LogAPI
 
     /**
      * On Server Alert Message
+     * Fired when the engine prints an alert message.
      * 
-     * @param array $request    Full request data with keys: Event, Server, Type, Message
+     * @param array $request {
+     *     @type string "Event"   "ServerAlertMessage"
+     *     @type array  "Server"  Server data
+     *     @type int    "Type"    The type of alert (usually 5 for at_logged)
+     *     @type string "Message" The text printed to the engine log
+     * }
      * 
-     * @return mixed            Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ServerAlertMessage($request)
     {
@@ -97,10 +131,14 @@ class LogAPI
 
     /**
      * On Server Update Information
+     * Fired periodically based on `log_api_delay`
      * 
-     * @param array $request    Full request data with keys: Event, Server
+     * @param array $request {
+     *     @type string "Event"  "ServerInfo"
+     *     @type array  "Server" Server data (includes inner 'Players' array with Auth, Name, UserId, Ip, Team, Ping, etc)
+     * }
      *
-     * @return mixed            Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ServerInfo($request)
     {
@@ -109,10 +147,15 @@ class LogAPI
 
     /**
      * On Client Connect
+     * Fired immediately when a client connects to the server (before entering).
      * 
-     * @param array $request    Full request data with keys: Event, Server, Player
+     * @param array $request {
+     *     @type string "Event"  "ClientConnect"
+     *     @type array  "Server" Server data
+     *     @type array  "Player" Player data (Auth, Name, UserId, EntityId, Ip, Team, Flags)
+     * }
      * 
-     * @return mixed            Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ClientConnect($request)
     {
@@ -121,10 +164,15 @@ class LogAPI
 
     /**
      * On Client Put In Server
+     * Fired when the player enters the game world for the first time.
      * 
-     * @param array $request    Full request data with keys: Event, Server, Player
+     * @param array $request {
+     *     @type string "Event"  "ClientPutInServer"
+     *     @type array  "Server" Server data
+     *     @type array  "Player" Player data
+     * }
      * 
-     * @return mixed            Array containing LogAPI commands or null
+     * @return mixed Array containing LogAPI commands or null
      */
     protected function ClientPutInServer($request)
     {
@@ -133,10 +181,17 @@ class LogAPI
 
     /**
      * On Client Disconnect
+     * Fired when a player leaves the server.
      * 
-     * @param array $request    Full request data with keys: Event, Server, Player, Crash, Reason
+     * @param array $request {
+     *     @type string "Event"   "ClientDisconnect"
+     *     @type array  "Server"  Server data
+     *     @type array  "Player"  Player data
+     *     @type bool   "Crash"   True if player dropped due to timeout/crash
+     *     @type string "Reason"  The drop reason string
+     * }
      * 
-     * @return mixed            Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ClientDisconnect($request)
     {
@@ -145,10 +200,19 @@ class LogAPI
 
     /**
      * On Client Killed
+     * Fired when a player dies.
      * 
-     * @param array $request    Full request data with keys: Event, Server, Player
+     * @param array $request {
+     *     @type string "Event"    "ClientKill"
+     *     @type array  "Server"   Server data
+     *     @type array  "Player"   The player who DIED (Victim)
+     *     @type array  "Attacker" The player who KILLED (optional, empty if world kill/suicide)
+     *     @type string "Weapon"   The weapon name used (e.g. "ak47")
+     *     @type bool   "Headshot" True if the kill was a headshot
+     *     @type bool   "Suicide"  True if the player killed themselves
+     * }
      * 
-     * @return mixed            Array containing LogAPI commands or null
+     * @return mixed Array containing LogAPI commands or null
      */
     protected function ClientKill($request)
     {
@@ -157,10 +221,16 @@ class LogAPI
 
     /**
      * On Client Information Changed
+     * Fired when a client changes their setinfo/keyinfobuffer.
      * 
-     * @param array $request    Full request data with keys: Event, Server, Player, InfoBuffer
+     * @param array $request {
+     *     @type string "Event"      "ClientUserInfoChanged"
+     *     @type array  "Server"     Server data
+     *     @type array  "Player"     Player data
+     *     @type string "InfoBuffer" The full new InfoBuffer string
+     * }
      * 
-     * @return mixed                Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ClientUserInfoChanged($request)
     {
@@ -169,10 +239,17 @@ class LogAPI
 
     /**
      * On Client Command
+     * Fired when a client executes ANY command in their client console.
      * 
-     * @param array $request    Full request data with keys: Event, Server, Player, Command, Args
+     * @param array $request {
+     *     @type string "Event"   "ClientCommand"
+     *     @type array  "Server"  Server data
+     *     @type array  "Player"  Player data
+     *     @type string "Command" The main command string executed
+     *     @type string "Args"    Arguments sent along with the command
+     * }
      * 
-     * @return mixed            Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ClientCommand($request)
     {
@@ -181,10 +258,17 @@ class LogAPI
 
     /**
      * On Client say or say_team commands
+     * Fired when a player talks in chat.
      * 
-     * @param array $request    Full request data with keys: Event, Server, Player, Type, Message
+     * @param array $request {
+     *     @type string "Event"   "ClientSay"
+     *     @type array  "Server"  Server data
+     *     @type array  "Player"  Player data
+     *     @type string "Type"    Chat type ("say" or "say_team")
+     *     @type string "Message" The actual message typed
+     * }
      * 
-     * @return mixed             Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ClientSay($request)
     {
@@ -193,10 +277,21 @@ class LogAPI
 
     /**
      * On Client menu handle command
+     * Triggered when a player presses a key on a general LogAPI menu.
      * 
-     * @param array $request    Full request data with keys: Event, Server, Player, Item (Info, Text, Disabled, Extra)
+     * @param array $request {
+     *     @type string "Event"  Depends on the callback string (e.g. "ClientMenuHandle")
+     *     @type array  "Server" Server data
+     *     @type array  "Player" Player data
+     *     @type array  "Item" {
+     *         @type int    "Info"     The Info key of the item
+     *         @type string "Text"     The display text
+     *         @type bool   "Disabled" If the item was disabled
+     *         @type string "Extra"    Any extra string passed
+     *     }
+     * }
      *
-     * @return mixed            Array containing LogAPI commands to server or null
+     * @return mixed Array containing LogAPI commands to server or null
      */
     protected function ClientMenuHandle($request)
     {

--- a/cstrike/addons/logapi/LogApi.php
+++ b/cstrike/addons/logapi/LogApi.php
@@ -6,7 +6,7 @@ class LogAPI
      * YOUR_API_TOKEN_CVAR must be exactly the same as configured
      * in the "log_api_bearer" cvar in the server's logapi.cfg
      */
-    private $logApiToken = "testandobearer";
+    private $logApiToken = "YOUR_API_TOKEN_CVAR";
 
     /**
      * Internal Whitelist for Security (PREVENTS RCE).


### PR DESCRIPTION
- Added the missing `log_api_exec_commands` Cvar to `cstrike/addons/logapi/logapi.cfg` and `README.md`.
- Rewrote the PHP example in `README.md` to be a production-ready template. It now includes the strict RCE whitelist, robust HTTP Authorization extraction (fixes Nginx/Apache 401s), and complex payload examples (Server Console debugs, Menu creation, and Kicks).
- Fully documented `cstrike/addons/logapi/LogApi.php` with beautiful, English PHPDoc comments detailing the exact structure of the JSON payload injected into the `$request` array for every possible event hook.
- For servers using php-fpm, it is necessary to adjust the .htaccess file so that it does not remove the access token.

.htaccess doc
```
# Pass the Authorization header to PHP-FPM
# Without this, Apache removes the header before it reaches PHP
RewriteEngine On
RewriteCond %{HTTP:Authorization} .

RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]

# Compatible alternative (SetEnvIf)
SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
```