### PR TITLE
fix(LogCurl): fix SIGSEGV on Linux caused by incorrect type in CURLOPT_PRIVATE

### DIFF
--- a/LogApi/LogCurl.cpp
+++ b/LogApi/LogCurl.cpp
@@ -26,9 +26,9 @@ void CLogCurl::ServerFrame() {
     while (ProcessedThisFrame < 5 && (MsgInfo = curl_multi_info_read(
                                           this->m_MultiHandle, &HandleCount))) {
       if (MsgInfo->msg == CURLMSG_DONE) {
-        int Index = 0;
-
-        curl_easy_getinfo(MsgInfo->easy_handle, CURLINFO_PRIVATE, &Index);
+        char *pPrivate = nullptr;
+        curl_easy_getinfo(MsgInfo->easy_handle, CURLINFO_PRIVATE, &pPrivate);
+        long Index = (long)(intptr_t)pPrivate;
 
         if (this->m_Data.find(Index) != this->m_Data.end()) {
           gLogApi.CallbackResult(MsgInfo->easy_handle, this->m_Data[Index].Size,
@@ -102,15 +102,15 @@ void CLogCurl::PostJSON(const char *url, long Timeout, std::string BearerToken,
         curl_easy_setopt(ch, CURLOPT_WRITEDATA,
                          (void *)&this->m_Data[this->m_RequestIndex]);
 
-        curl_easy_setopt(ch, CURLOPT_PRIVATE, this->m_RequestIndex);
+        curl_easy_setopt(ch, CURLOPT_PRIVATE, (void*)(intptr_t)this->m_RequestIndex);
 
         curl_multi_add_handle(this->m_MultiHandle, ch);
 
-        this->m_RequestIndex++;
-
-        if (this->m_RequestIndex < 0) {
+        if (this->m_RequestIndex >= LONG_MAX) {
           this->m_RequestIndex = 1;
         }
+
+        this->m_RequestIndex++;
       }
     }
   }


### PR DESCRIPTION
## Problem

The module was causing a SIGSEGV on startup in Linux. The crash occurred during loading via `ld-linux.so.2`, indicating runtime memory corruption.

## Root Cause

Three related bugs in `LogCurl.cpp`:

**1. Incorrect type in `CURLOPT_PRIVATE` (main cause)**
The libcurl API expects a `void*` for `CURLOPT_PRIVATE` and a `char*` when retrieving it via `CURLINFO_PRIVATE`. The code was passing a `long` directly, which worked by accident on 32-bit Windows (same size as a pointer), but on Linux it caused the value to be interpreted as an invalid memory address → SIGSEGV.

**2. Using `int` when retrieving the index via `CURLINFO_PRIVATE`**
`curl_easy_getinfo` was writing a pointer into an `int` variable, causing incorrect size reads and potential stack corruption.

**3. Incorrect overflow check in `m_RequestIndex`**
The check `if (m_RequestIndex < 0)` never triggered on Linux because the compiler with `-O3` optimizations removes code that relies on signed integer overflow (undefined behavior in C++).

## Fixes

* `CURLOPT_PRIVATE`: cast to `(void*)(intptr_t)` when storing
* `CURLINFO_PRIVATE`: retrieve as `char*` and convert using `(long)(intptr_t)`
* Overflow: changed check to `if (m_RequestIndex >= LONG_MAX)` before increment

## Files Changed

* `LogApi/LogCurl.cpp`
